### PR TITLE
https://issues.apache.org/jira/browse/LOG4NET-552

### DIFF
--- a/src/Appender/FileAppender.cs
+++ b/src/Appender/FileAppender.cs
@@ -371,21 +371,22 @@ namespace log4net.Appender
 		{
 			private FileAppender m_appender = null;
 
-			/// <summary>
-			/// Open the output file
-			/// </summary>
-			/// <param name="filename">The filename to use</param>
-			/// <param name="append">Whether to append to the file, or overwrite</param>
-			/// <param name="encoding">The encoding to use</param>
-			/// <remarks>
-			/// <para>
-			/// Open the file specified and prepare for logging.
-			/// No writes will be made until <see cref="AcquireLock"/> is called.
-			/// Must be called before any calls to <see cref="AcquireLock"/>,
-			/// <see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
-			/// </para>
-			/// </remarks>
-			public abstract void OpenFile(string filename, bool append, Encoding encoding);
+            /// <summary>
+            /// Open the output file
+            /// </summary>
+            /// <param name="filename">The filename to use</param>
+            /// <param name="append">Whether to append to the file, or overwrite</param>
+            /// <param name="encoding">The encoding to use</param>
+            /// <param name="useMutexWithMinimalLock">Whether to protect append operation in Minimal lock with Mutex </param>
+            /// <remarks>
+            /// <para>
+            /// Open the file specified and prepare for logging.
+            /// No writes will be made until <see cref="AcquireLock"/> is called.
+            /// Must be called before any calls to <see cref="AcquireLock"/>,
+            /// <see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
+            /// </para>
+            /// </remarks>
+            public abstract void OpenFile(string filename, bool append, Encoding encoding, bool useMutexWithMinimalLock = false);
 
 			/// <summary>
 			/// Close the file
@@ -456,23 +457,23 @@ namespace log4net.Appender
 				set { m_appender = value; }
 			}
 
-			/// <summary>
-			/// Helper method that creates a FileStream under CurrentAppender's SecurityContext.
-			/// </summary>
-			/// <remarks>
-			/// <para>
-			/// Typically called during OpenFile or AcquireLock.
-			/// </para>
-			/// <para>
-			/// If the directory portion of the <paramref name="filename"/> does not exist, it is created
-			/// via Directory.CreateDirecctory.
-			/// </para>
-			/// </remarks>
-			/// <param name="filename"></param>
-			/// <param name="append"></param>
-			/// <param name="fileShare"></param>
-			/// <returns></returns>
-			protected Stream CreateStream(string filename, bool append, FileShare fileShare)
+            /// <summary>
+            /// Helper method that creates a FileStream under CurrentAppender's SecurityContext.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// Typically called during OpenFile or AcquireLock.
+            /// </para>
+            /// <para>
+            /// If the directory portion of the <paramref name="filename"/> does not exist, it is created
+            /// via Directory.CreateDirecctory.
+            /// </para>
+            /// </remarks>
+            /// <param name="filename"></param>
+            /// <param name="append"></param>
+            /// <param name="fileShare"></param>
+            /// <returns></returns>
+            protected Stream CreateStream(string filename, bool append, FileShare fileShare)
 			{
 				using (CurrentAppender.SecurityContext.Impersonate(this))
 				{
@@ -520,21 +521,22 @@ namespace log4net.Appender
 		{
 			private Stream m_stream = null;
 
-			/// <summary>
-			/// Open the file specified and prepare for logging.
-			/// </summary>
-			/// <param name="filename">The filename to use</param>
-			/// <param name="append">Whether to append to the file, or overwrite</param>
-			/// <param name="encoding">The encoding to use</param>
-			/// <remarks>
-			/// <para>
-			/// Open the file specified and prepare for logging.
-			/// No writes will be made until <see cref="AcquireLock"/> is called.
-			/// Must be called before any calls to <see cref="AcquireLock"/>,
-			/// <see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
-			/// </para>
-			/// </remarks>
-			public override void OpenFile(string filename, bool append, Encoding encoding)
+            /// <summary>
+            /// Open the file specified and prepare for logging.
+            /// </summary>
+            /// <param name="filename">The filename to use</param>
+            /// <param name="append">Whether to append to the file, or overwrite</param>
+            /// <param name="encoding">The encoding to use</param>
+            /// <param name="useMutexWithMinimalLock">Whether to protect append operation in Minimal lock with Mutex </param>
+            /// <remarks>
+            /// <para>
+            /// Open the file specified and prepare for logging.
+            /// No writes will be made until <see cref="AcquireLock"/> is called.
+            /// Must be called before any calls to <see cref="AcquireLock"/>,
+            /// <see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
+            /// </para>
+            /// </remarks>
+            public override void OpenFile(string filename, bool append, Encoding encoding, bool useMutexWithMinimalLock = false)
 			{
 				try
 				{
@@ -621,13 +623,16 @@ namespace log4net.Appender
 			private bool m_append;
 			private Stream m_stream = null;
             private Mutex m_appendMutex = null;
-            private string m_appendMutexFriendlyName = "MUTEX_INTERPROCESS_COMMUNICATION_ACROSS_PROCESSES";
+            private string m_appendMutexFriendlyName = "LOG4NET_MUTEX_ON_MINIMALLOCK_TO_PROTECT_APPEND_OPERATION";
+            private bool m_useMutexWithMinimalLock = false;
+
             /// <summary>
             /// Prepares to open the file when the first message is logged.
             /// </summary>
             /// <param name="filename">The filename to use</param>
             /// <param name="append">Whether to append to the file, or overwrite</param>
             /// <param name="encoding">The encoding to use</param>
+            /// <param name="useMutexWithMinimalLock">Whether to protect append operation in Minimal lock with Mutex </param>
             /// <remarks>
             /// <para>
             /// Open the file specified and prepare for logging.
@@ -636,11 +641,13 @@ namespace log4net.Appender
             /// <see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
             /// </para>
             /// </remarks>
-            public override void OpenFile(string filename, bool append, Encoding encoding)
+            public override void OpenFile(string filename, bool append, Encoding encoding, bool useMutexWithMinimalLock = false)
 			{
 				m_filename = filename;
 				m_append = append;
-			}
+                m_useMutexWithMinimalLock = useMutexWithMinimalLock;
+
+            }
 
 			/// <summary>
 			/// Close the file
@@ -672,13 +679,18 @@ namespace log4net.Appender
 				{
 					try
 					{
-                        if (m_appendMutex == null)
+                        if (m_useMutexWithMinimalLock)
                         {
-                            if (!Mutex.TryOpenExisting(m_appendMutexFriendlyName, out m_appendMutex))
-                                m_appendMutex = new Mutex(false, m_appendMutexFriendlyName);
-                        }
+                            if (m_appendMutex == null)
+                            {
+                                if (!Mutex.TryOpenExisting(m_appendMutexFriendlyName, out m_appendMutex))
+                                {
+                                    m_appendMutex = new Mutex(false, m_appendMutexFriendlyName);
+                                }
+                            }
 
-                        m_appendMutex.WaitOne();
+                            m_appendMutex.WaitOne();
+                        }
 
                         m_stream = CreateStream(m_filename, m_append, FileShare.Read);
 						m_append = true;
@@ -705,8 +717,13 @@ namespace log4net.Appender
 				CloseStream(m_stream);
 				m_stream = null;
 
-                if (m_appendMutex != null)
-                    m_appendMutex.ReleaseMutex();
+                if (m_useMutexWithMinimalLock)
+                {
+                    if (m_appendMutex != null)
+                    {
+                        m_appendMutex.ReleaseMutex();
+                    }
+                }
             }
 
 			/// <summary>
@@ -738,24 +755,25 @@ namespace log4net.Appender
 			private Stream m_stream = null;
 			private int m_recursiveWatch = 0;
 
-			/// <summary>
-			/// Open the file specified and prepare for logging.
-			/// </summary>
-			/// <param name="filename">The filename to use</param>
-			/// <param name="append">Whether to append to the file, or overwrite</param>
-			/// <param name="encoding">The encoding to use</param>
-			/// <remarks>
-			/// <para>
-			/// Open the file specified and prepare for logging.
-			/// No writes will be made until <see cref="AcquireLock"/> is called.
-			/// Must be called before any calls to <see cref="AcquireLock"/>,
-			/// -<see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
-			/// </para>
-			/// </remarks>
+            /// <summary>
+            /// Open the file specified and prepare for logging.
+            /// </summary>
+            /// <param name="filename">The filename to use</param>
+            /// <param name="append">Whether to append to the file, or overwrite</param>
+            /// <param name="encoding">The encoding to use</param>
+            /// <param name="useMutexWithMinimalLock">Whether to protect append operation in Minimal lock with Mutex </param>
+            /// <remarks>
+            /// <para>
+            /// Open the file specified and prepare for logging.
+            /// No writes will be made until <see cref="AcquireLock"/> is called.
+            /// Must be called before any calls to <see cref="AcquireLock"/>,
+            /// -<see cref="ReleaseLock"/> and <see cref="CloseFile"/>.
+            /// </para>
+            /// </remarks>
 #if NET_4_0 || MONO_4_0 || NETSTANDARD1_3
-			[System.Security.SecuritySafeCritical]
+            [System.Security.SecuritySafeCritical]
 #endif
-			public override void OpenFile(string filename, bool append, Encoding encoding)
+			public override void OpenFile(string filename, bool append, Encoding encoding, bool useMutexWithMinimalLock = false)
 			{
 				try
 				{
@@ -1070,30 +1088,48 @@ namespace log4net.Appender
 			set { m_lockingModel = value; }
 		}
 
-		#endregion Public Instance Properties
+        /// <summary>
+        /// Gets or sets a value indicating whether to protect append operation in Minimal lock with Mutex.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if append operation with Minimal lock should be protected from multiple processes appending into same file, otherwise <c>false</c>
+        /// </value>
+        /// <remarks>
+        /// <para>
+        /// By default append operation in Minimal lock won't be protected 
+        /// from multiple processes appending into same file.
+        /// </para>
+        /// </remarks>
+        public bool UseMutexWithMinimalLock
+        {
+            get { return m_useMutexWithMinimalLock; }
+            set { m_useMutexWithMinimalLock = value; }
+        }
 
-		#region Override implementation of AppenderSkeleton
+        #endregion Public Instance Properties
 
-		/// <summary>
-		/// Activate the options on the file appender.
-		/// </summary>
-		/// <remarks>
-		/// <para>
-		/// This is part of the <see cref="IOptionHandler"/> delayed object
-		/// activation scheme. The <see cref="ActivateOptions"/> method must
-		/// be called on this object after the configuration properties have
-		/// been set. Until <see cref="ActivateOptions"/> is called this
-		/// object is in an undefined state and must not be used.
-		/// </para>
-		/// <para>
-		/// If any of the configuration properties are modified then
-		/// <see cref="ActivateOptions"/> must be called again.
-		/// </para>
-		/// <para>
-		/// This will cause the file to be opened.
-		/// </para>
-		/// </remarks>
-		override public void ActivateOptions()
+        #region Override implementation of AppenderSkeleton
+
+        /// <summary>
+        /// Activate the options on the file appender.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is part of the <see cref="IOptionHandler"/> delayed object
+        /// activation scheme. The <see cref="ActivateOptions"/> method must
+        /// be called on this object after the configuration properties have
+        /// been set. Until <see cref="ActivateOptions"/> is called this
+        /// object is in an undefined state and must not be used.
+        /// </para>
+        /// <para>
+        /// If any of the configuration properties are modified then
+        /// <see cref="ActivateOptions"/> must be called again.
+        /// </para>
+        /// <para>
+        /// This will cause the file to be opened.
+        /// </para>
+        /// </remarks>
+        override public void ActivateOptions()
 		{
 			base.ActivateOptions();
 
@@ -1383,7 +1419,7 @@ namespace log4net.Appender
 				m_appendToFile = append;
 
 				LockingModel.CurrentAppender = this;
-				LockingModel.OpenFile(fileName, append, m_encoding);
+				LockingModel.OpenFile(fileName, append, m_encoding, m_useMutexWithMinimalLock);
 				m_stream = new LockingStream(LockingModel);
 
 				if (m_stream != null)
@@ -1496,18 +1532,23 @@ namespace log4net.Appender
 		/// </summary>
 		private FileAppender.LockingModelBase m_lockingModel = new FileAppender.ExclusiveLock();
 
-		#endregion Private Instance Fields
+        /// <summary>
+        /// Value indicating whether to protect append operation in Minimal lock with Mutex.
+        /// </summary>
+        private bool m_useMutexWithMinimalLock = false;
 
-		#region Private Static Fields
+        #endregion Private Instance Fields
 
-		/// <summary>
-		/// The fully qualified type of the FileAppender class.
-		/// </summary>
-		/// <remarks>
-		/// Used by the internal logger to record the Type of the
-		/// log message.
-		/// </remarks>
-		private readonly static Type declaringType = typeof(FileAppender);
+        #region Private Static Fields
+
+        /// <summary>
+        /// The fully qualified type of the FileAppender class.
+        /// </summary>
+        /// <remarks>
+        /// Used by the internal logger to record the Type of the
+        /// log message.
+        /// </remarks>
+        private readonly static Type declaringType = typeof(FileAppender);
 
 		#endregion Private Static Fields
 	}

--- a/src/Appender/RollingFileAppender.cs
+++ b/src/Appender/RollingFileAppender.cs
@@ -536,18 +536,18 @@ namespace log4net.Appender
 			set { m_staticLogFileName = value; }
 		}
 
-		#endregion Public Instance Properties
+        #endregion Public Instance Properties
 
-		#region Private Static Fields
+        #region Private Static Fields
 
-		/// <summary>
-		/// The fully qualified type of the RollingFileAppender class.
-		/// </summary>
-		/// <remarks>
-		/// Used by the internal logger to record the Type of the
-		/// log message.
-		/// </remarks>
-		private readonly static Type declaringType = typeof(RollingFileAppender);
+        /// <summary>
+        /// The fully qualified type of the RollingFileAppender class.
+        /// </summary>
+        /// <remarks>
+        /// Used by the internal logger to record the Type of the
+        /// log message.
+        /// </remarks>
+        private readonly static Type declaringType = typeof(RollingFileAppender);
 
 		#endregion Private Static Fields
 
@@ -626,8 +626,8 @@ namespace log4net.Appender
 					DateTime n = m_dateTime.Now;
 					if (n >= m_nextCheck)
 					{
-						m_now = n;
-						m_nextCheck = NextCheckDate(m_now, m_rollPoint);
+                        m_now = n;
+                        m_nextCheck = NextCheckDate(m_now, m_rollPoint);
 
                         if (!FileExists(m_scheduledFilename))
                         {
@@ -639,7 +639,7 @@ namespace log4net.Appender
                             m_scheduledFilename = CombinePath(File, m_now.ToString(m_datePattern, System.Globalization.DateTimeFormatInfo.InvariantInfo));
                         }
                     }
-				}
+                }
 
 				if (m_rollSize)
 				{
@@ -1687,10 +1687,10 @@ namespace log4net.Appender
 		/// </summary>
 		private bool m_staticLogFileName = true;
 
-		/// <summary>
-		/// Value indicating whether to preserve the file name extension when rolling.
-		/// </summary>
-		private bool m_preserveLogFileNameExtension = false;
+        /// <summary>
+        /// Value indicating whether to preserve the file name extension when rolling.
+        /// </summary>
+        private bool m_preserveLogFileNameExtension = false;
 
 
 		/// <summary>

--- a/src/Appender/RollingFileAppender.cs
+++ b/src/Appender/RollingFileAppender.cs
@@ -629,8 +629,16 @@ namespace log4net.Appender
 						m_now = n;
 						m_nextCheck = NextCheckDate(m_now, m_rollPoint);
 
-						RollOverTime(true);
-					}
+                        if (!FileExists(m_scheduledFilename))
+                        {
+                            RollOverTime(true);
+                        }
+                        else
+                        {
+                            //As we are skiping rollOver, we need to pupulate new scheduled name
+                            m_scheduledFilename = CombinePath(File, m_now.ToString(m_datePattern, System.Globalization.DateTimeFormatInfo.InvariantInfo));
+                        }
+                    }
 				}
 
 				if (m_rollSize)


### PR DESCRIPTION
services installed on production box are separate process and are configured to write log into single log file. Due to this following two issues are happening,

During write/append operation some processes are failing with error “Unable to acquire lock on file. The process cannot access the file because it is being used by another process”. This is because one process acquires lock (thread safe not process safe) for writing into log file and simultaneously another is trying to acquire lock and fails with above error and it just skips writing into log file.

During rolling operation, rolled file gets created with less than 1KB size. Thus log entries are lost. Upon investigation we found that, rolling operation is protected by system wide Mutex lock. At the time of rolling, multiple processes may come at the same time for rolling and first process will roll the original file correctly and give a different name to rolled file and re-create blank original file. Now the second process which would have come for rolling will roll the blank original file and overwrite the rolled file created by first process and thus rolled file is losing the data.

We locally have fixed above issues by changing latest log4net source code. We have kept locking model as “MinimalLock” which is current configuration in production. During append operation for acquirelock/releaselock we added system wide mutex so that each process will wait for other process to complete append operation. Thus it will not skip log from being written.

During rolling operation we added check whether rolling is already happened by some other process. If yes then skip rolling operation. This will resolve rolling file overwrite by other process issue.