### PR TITLE
Save one frame from being accessed twice unnecessarily in ctor of LocationInfo

### DIFF
--- a/src/Core/LocationInfo.cs
+++ b/src/Core/LocationInfo.cs
@@ -95,11 +95,11 @@ namespace log4net.Core
 					while (frameIndex < st.FrameCount)
 					{
 						StackFrame frame = st.GetFrame(frameIndex);
+						frameIndex++;
 						if (frame != null && frame.GetMethod().DeclaringType == callerStackBoundaryDeclaringType)
 						{
 							break;
 						}
-						frameIndex++;
 					}
 
 					// skip frames from fqnOfCallingClass


### PR DESCRIPTION
The last frame in stack with declaringType as callerStackBoundaryDeclaringType was being accessed in both while loops.