### PR TITLE
'(doc)' make the method RollingFileAppender.RollFile() virtual.

### DIFF
--- a/src/Appender/RollingFileAppender.cs
+++ b/src/Appender/RollingFileAppender.cs
@@ -1269,7 +1269,7 @@ namespace log4net.Appender
 		/// also checks for existence of target file and deletes if it does.
 		/// </para>
 		/// </remarks>
-		protected void RollFile(string fromFile, string toFile) 
+		protected virtual void RollFile(string fromFile, string toFile) 
 		{
 			if (FileExists(fromFile))
 			{


### PR DESCRIPTION
I need to post process rolled file by archiver and I can hardly achieve it without making this method virtual.