### PR TITLE
Fixes LOG4NET-587 Mutex ~ UnauthorizedAccessException Access to the path is denied

### DIFF
--- a/src/Appender/FileAppender.cs
+++ b/src/Appender/FileAppender.cs
@@ -888,7 +888,7 @@ namespace log4net.Appender
 				return null;
 			}
 
-			return Regex.Replace(filePath, "[" + new string(Path.GetInvalidFileNameChars()) + "]", "_");
+			return Regex.Replace(filePath, "[" + new string(Path.GetInvalidFileNameChars()).Replace(@"\", @"\\") + "]", "_");
 		}
 
 		/// <summary>

--- a/src/Appender/RollingFileAppender.cs
+++ b/src/Appender/RollingFileAppender.cs
@@ -250,7 +250,6 @@ namespace log4net.Appender
 				m_mutexForRolling.Close();
 #endif
 				m_mutexForRolling = null;
-				m_mutexNameForRolling = null;
 			}
 #endif
 		}
@@ -1151,16 +1150,11 @@ namespace log4net.Appender
 			if (m_mutexForRolling == null)
 			{
 				// initialize the mutex that is used to lock rolling
-				string mutexFriendlyFilename = m_baseFileName.Replace("\\", "_").Replace(":", "_").Replace("/", "_");
-				m_mutexNameForRolling = mutexFriendlyFilename;
-
-				LogLog.Debug(declaringType, $"Creating mutex for rolling file. Mutex name: \"{m_mutexNameForRolling}\", current file: {m_baseFileName} .");
-
-				m_mutexForRolling = SecureCreateMutex(mutexFriendlyFilename, this.ErrorHandler);
+				m_mutexForRolling = SecureCreateMutexForFilePath(m_baseFileName);
 			}
 			else
 			{
-				this.ErrorHandler.Error($"Programming error, mutex for rolling file already initialized! Mutex name: \"{m_mutexNameForRolling}\", current file: {m_baseFileName} .");
+				this.ErrorHandler.Error($"Programming error, mutex for rolling file already initialized! Activating RollingFileAppender more than once is incorrect. Current file: {m_baseFileName} .");
 			}
 #endif
 
@@ -1708,8 +1702,6 @@ namespace log4net.Appender
 		/// A mutex that is used to lock rolling of files.
 		/// </summary>
 		private Mutex m_mutexForRolling;
-
-		private string m_mutexNameForRolling = null;
 #endif
 
 		#endregion Private Instance Fields


### PR DESCRIPTION
This pull request fixes [LOG4NET-587](https://issues.apache.org/jira/browse/LOG4NET-587) issue: Mutex ~ UnauthorizedAccessException Access to the path is denied. 

I fixed this issue as suggested by [Dominik Psenner](https://issues.apache.org/jira/browse/LOG4NET-587?focusedCommentId=16326387&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16326387) see the fix suggestion [here](https://stackoverflow.com/questions/19536697/unauthorizedaccessexception-when-trying-to-open-a-mutex).

I experienced this bug often, until I fixed and successfully tested it.
We have many .Net 4.0 Web Services (WCF) and ASPX pages hosted in IIS, where I newly integrated log4net for a sake of quick high level error tracing, as a last resort if the legacy functionality does not trace anything. 
After fixing the error above and testing I simplified things and went to using the base FileAppender, because of several further issues with rolling, so the Mutexes are no more an issue also with the currently latest stable log4net 2.0.8

There seem to be several similar issues as well, which may be worth checking with this fix, e.g.: LOG4NET-496, LOG4NET-506, LOG4NET-525, LOG4NET-560, LOG4NET-599, LOG4NET-612