### PR TITLE
Fixes LOG4NET-630 Log4Net missing Timestamp etc. in internal LogLog

### DIFF
--- a/src/Util/LogLog.cs
+++ b/src/Util/LogLog.cs
@@ -177,6 +177,16 @@ namespace log4net.Util
 				InternalDebugging = OptionConverter.ToBoolean(SystemInfo.GetAppSetting("log4net.Internal.Debug"), false);
 				QuietMode = OptionConverter.ToBoolean(SystemInfo.GetAppSetting("log4net.Internal.Quiet"), false);
 				EmitInternalMessages = OptionConverter.ToBoolean(SystemInfo.GetAppSetting("log4net.Internal.Emit"), true);
+				s_logMsgPrefixPattern = SystemInfo.GetAppSetting("log4net.Internal.LogMsgPrefixPattern");
+
+				if (string.IsNullOrWhiteSpace(s_logMsgPrefixPattern))
+				{
+					s_logMsgPrefixPattern = null;
+				}
+				else
+				{
+					s_logMsgPrefixPatternLayout = new PatternString(s_logMsgPrefixPattern);
+				}
 			}
 			catch(Exception ex)
 			{
@@ -538,6 +548,7 @@ namespace log4net.Util
 		{
 			try
 			{
+				message = AddTimestampAndCoPrefix(message);
 #if NETCF
 				Console.WriteLine(message);
 				//System.Diagnostics.Debug.WriteLine(message);
@@ -572,6 +583,7 @@ namespace log4net.Util
 		{
 			try
 			{
+				message = AddTimestampAndCoPrefix(message);
 #if NETCF
 				Console.WriteLine(message);
 				//System.Diagnostics.Debug.WriteLine(message);
@@ -584,6 +596,15 @@ namespace log4net.Util
 			{
 				// Ignore exception, what else can we do? Not really a good idea to propagate back to the caller
 			}
+		}
+
+		private static string AddTimestampAndCoPrefix(string message)
+		{
+			if (s_logMsgPrefixPatternLayout != null)
+			{
+				message = $"{s_logMsgPrefixPatternLayout.Format()} {message}";
+			}
+			return message;
 		}
 
 		#region Private Static Fields
@@ -599,6 +620,9 @@ namespace log4net.Util
 		private static bool s_quietMode = false;
 
 		private static bool s_emitInternalMessages = true;
+
+		private static string s_logMsgPrefixPattern = null;
+		private static PatternString s_logMsgPrefixPatternLayout = null;
 
 		private const string PREFIX			= "log4net: ";
 		private const string ERR_PREFIX		= "log4net:ERROR ";

--- a/src/Util/PatternString.cs
+++ b/src/Util/PatternString.cs
@@ -308,6 +308,7 @@ namespace log4net.Util
 			s_globalRulesRegistry.Add("literal", typeof(LiteralPatternConverter));
 			s_globalRulesRegistry.Add("newline", typeof(NewLinePatternConverter));
 			s_globalRulesRegistry.Add("processid", typeof(ProcessIdPatternConverter));
+			s_globalRulesRegistry.Add("thread", typeof(ThreadIdPatternConverter));
 			s_globalRulesRegistry.Add("property", typeof(PropertyPatternConverter));
 			s_globalRulesRegistry.Add("random", typeof(RandomStringPatternConverter));
 			s_globalRulesRegistry.Add("username", typeof(UserNamePatternConverter));

--- a/src/Util/PatternStringConverters/ThreadIdPatternConverter.cs
+++ b/src/Util/PatternStringConverters/ThreadIdPatternConverter.cs
@@ -1,0 +1,67 @@
+#region Apache License
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more 
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership. 
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with 
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Text;
+using System.IO;
+
+using log4net.Util;
+
+namespace log4net.Util.PatternStringConverters
+{
+	/// <summary>
+	/// Write the current Thread ID to the output
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Write the current Thread ID to the output writer
+	/// </para>
+	/// </remarks>
+	/// <author>Nicko Cadell</author>
+	internal sealed class ThreadIdPatternConverter : PatternConverter 
+	{
+		/// <summary>
+		/// Write the current Thread ID to the output
+		/// </summary>
+		/// <param name="writer">the writer to write to</param>
+		/// <param name="state">null, state is not set</param>
+		/// <remarks>
+		/// <para>
+		/// Write the current Thread ID to the output <paramref name="writer"/>.
+		/// </para>
+		/// </remarks>
+		override protected void Convert(TextWriter writer, object state) 
+		{
+			writer.Write( SystemInfo.CurrentThreadId );
+		}
+
+		#region Private Static Fields
+
+		/// <summary>
+		/// The fully qualified type of the ThreadIdPatternConverter class.
+		/// </summary>
+		/// <remarks>
+		/// Used by the internal logger to record the Type of the
+		/// log message.
+		/// </remarks>
+		private readonly static Type declaringType = typeof(ThreadIdPatternConverter);
+
+		#endregion Private Static Fields
+	}
+}

--- a/src/log4net.csproj
+++ b/src/log4net.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 
  Licensed to the Apache Software Foundation (ASF) under one
@@ -692,6 +692,7 @@
     <Compile Include="Util\PatternStringConverters\RandomStringPatternConverter.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Util\PatternStringConverters\ThreadIdPatternConverter.cs" />
     <Compile Include="Util\PatternStringConverters\UserNamePatternConverter.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
The Issue [LOG4NET-630](https://issues.apache.org/jira/browse/LOG4NET-630) is fixed with this pull request.

Now you can configure in the Web.Config / App.Config what you want to see in the internal log4net Log.
For example:

&lt;appSettings&gt;
  &lt;add key=&quot;log4net.Internal.Debug&quot; value=&quot;true&quot;/&gt;
  &lt;add key=&quot;**log4net.Internal.LogMsgPrefixPattern**&quot; value=&quot;**%date [%7processid][%3thread][%appdomain]**&quot;/&gt;
&lt;/appSettings&gt;

to get log4net internal trace messages like this:
`2019-05-22 13:51:30,266 [   5984][  3][/LM/W3SVC/1/ROOT/sw-f-ch-dn-1-132029994898417032] log4net: defaultRepositoryType [log4net.Repository.Hierarchy.Hierarchy]`
...
`2019-05-22 13:51:30,322 [   5984][  3][/LM/W3SVC/1/ROOT/sw-f-ch-dn-1-132029994898417032] log4net: Adding appender named [LogFile] to logger [root].`

