### PR TITLE
Fix AdoNetAppender using npgsql

### DIFF
--- a/src/log4net/Appender/AdoNetAppender.cs
+++ b/src/log4net/Appender/AdoNetAppender.cs
@@ -553,8 +553,17 @@ namespace log4net.Appender
 					{
 						dbCmd.Transaction = dbTran;
 					}
-					// prepare the command, which is significantly faster
-					dbCmd.Prepare();
+
+					try
+					{
+						// prepare the command, which is significantly faster
+						dbCmd.Prepare();
+					}
+					catch (Exception)
+					{
+						// ignore prepare exceptions as they can happen without affecting actual logging, eg on npgsql
+					}
+
 					// run for all events
 					foreach (LoggingEvent e in events)
 					{


### PR DESCRIPTION
Using npgsql on netfx and mono I've encountered this error on an applicaiton startup:
```
log4net:ERROR [CustomAdoNetAppender] ErrorCode: GenericFailure. Exception while writing to database
Npgsql.PostgresException (0x80004005): 42601: syntax error at or near ":"
   at Npgsql.NpgsqlConnector.DoReadMessage(Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications, Boolean isPrependedMessage)
   at Npgsql.NpgsqlConnector.ReadMessage(Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications)
   at Npgsql.NpgsqlConnector.ReadMessage(Boolean async, DataRowLoadingMode dataRowLoadingMode, Boolean readingNotifications)
   at Npgsql.NpgsqlConnector.ReadExpecting[T](Boolean async)
   at Npgsql.NpgsqlCommand.Prepare()
   at log4net.Appender.AdoNetAppender.SendBuffer(IDbTransaction dbTran, LoggingEvent[] events)
   at log4net.Appender.AdoNetAppender.SendBuffer(LoggingEvent[] events)
```
The error prevents to write **only** very first logging event, because Npgsql fails to prepare command with no parameters (at a moment). So it is not a problem in general, but disturbing.

I think my _fix_ is not that good but does a trick.

An alternative is to disable `dbCmd.Prepare();` if it fails once, but it is overkill, cuz there is no second fail.
```
					if (m_doCommandPrepare)
					{
						try
						{
							// prepare the command, which is significantly faster
							dbCmd.Prepare();
						}
						catch (Exception)
						{
							m_doCommandPrepare = false;
						}
					}
...
		private bool m_doCommandPrepare = true;
```
