### PR TITLE
adds ActivatorProvider to allow custom type activation (Resolves LOG4NET-565)

### DIFF
--- a/src/log4net.Tests/Appender/CountingAppenderWithDependency.cs
+++ b/src/log4net.Tests/Appender/CountingAppenderWithDependency.cs
@@ -1,0 +1,25 @@
+﻿using log4net.Appender;
+using log4net.Core;
+
+namespace log4net.Tests.Appender
+{
+    public class CountingContext
+    {
+        public int Count { get; set; }
+    }
+
+    public class CountingAppenderWithDependency : AppenderSkeleton
+    {
+        public CountingAppenderWithDependency(CountingContext context)
+        {
+            Context = context;
+        }
+
+        protected CountingContext Context { get; }
+
+        protected override void Append(LoggingEvent loggingEvent)
+        {
+            Context.Count++;
+        }
+    }
+}

--- a/src/log4net.Tests/Core/ActivatorProviderTest.cs
+++ b/src/log4net.Tests/Core/ActivatorProviderTest.cs
@@ -1,0 +1,97 @@
+﻿using log4net.Core;
+using log4net.Tests.Appender;
+using NUnit.Framework;
+using System;
+
+#if NETSTANDARD1_3
+using System.Reflection;
+#endif
+using System.Linq;
+
+namespace log4net.Tests.Core
+{
+    [TestFixture]
+    public class ActivatorProviderTest
+    {
+		/// <summary>
+		/// Any initialization that happens before each test can
+		/// go here
+		/// </summary>
+		[SetUp]
+		public void SetUp()
+		{
+		}
+
+		[TearDown]
+		public void TearDown()
+        {
+			// this is set by default, but could have been changed in the tests.
+			ActivatorProvider.Instance = new DefaultActivator();
+		}
+
+		/// <summary>
+		/// Test whether an instance can be created using the default activator.
+		/// </summary>
+		[Test]
+		public void TestCanCreateInstanceDefaultActivator()
+		{
+			var type = typeof(CountingAppender);
+			var result = ActivatorProvider.CanCreateInstance(type);
+
+			Assert.IsTrue(result);
+		}
+
+
+		/// <summary>
+		/// Test retrieving an appender without dependencies using the default activator.
+		/// </summary>
+		[Test]
+		public void TestCreateInstanceDefaultActivator()
+		{
+			var type = typeof(CountingAppender);
+			var result = ActivatorProvider.CreateInstance(type);
+
+			Assert.IsInstanceOf(type, result);
+		}
+
+		/// <summary>
+		/// Test retrieving an appender with dependencies using the default activator.
+		/// </summary>
+		[Test]
+		public void TestCreateInstanceWithDependenciesDefaultActivator_ThrowsException()
+		{
+			var type = typeof(CountingAppenderWithDependency);
+			Assert.Throws<MissingMethodException>(() => ActivatorProvider.CreateInstance(type));
+		}
+
+		/// <summary>
+		/// Test retrieving an appender with dependencies using the custom activator.
+		/// </summary>
+		[Test]
+		public void TestCreateInstanceWithDependenciesCustomActivator()
+		{
+			ActivatorProvider.Instance = new CustomActivator();
+
+			var type = typeof(CountingAppenderWithDependency);
+			var result = ActivatorProvider.CreateInstance(type);
+
+			Assert.IsInstanceOf(type, result);
+		}
+
+		private class CustomActivator : IActivator
+        {
+            public bool CanCreateInstance(Type type)
+            {
+				return true;
+            }
+
+            public object CreateInstance(Type type)
+            {
+				var ctor = type.GetConstructors().First();
+				var parameters = ctor.GetParameters();
+				var arguments = parameters.Select(p => CreateInstance(p.ParameterType)).ToArray();
+				return ctor.Invoke(arguments);
+            }
+        }
+    }
+}

--- a/src/log4net/Appender/AdoNetAppender.cs
+++ b/src/log4net/Appender/AdoNetAppender.cs
@@ -643,7 +643,7 @@ namespace log4net.Appender
 		/// <returns>An <see cref="IDbConnection"/> instance with a valid connection string.</returns>
 		protected virtual IDbConnection CreateConnection(Type connectionType, string connectionString)
 		{
-			IDbConnection connection = (IDbConnection)Activator.CreateInstance(connectionType);
+			IDbConnection connection = (IDbConnection)ActivatorProvider.CreateInstance(connectionType);
 			connection.ConnectionString = connectionString;
 			return connection;
 		}

--- a/src/log4net/Config/PluginAttribute.cs
+++ b/src/log4net/Config/PluginAttribute.cs
@@ -23,10 +23,8 @@
 using System;
 
 using log4net.Core;
-#if !NETSTANDARD1_3
-using log4net.Util;
-#endif
 using log4net.Plugin;
+using log4net.Util;
 
 namespace log4net.Config
 {
@@ -155,8 +153,8 @@ namespace log4net.Config
 				throw new LogException("Plugin type [" + pluginType.FullName + "] does not implement the log4net.IPlugin interface");
 			}
 
-			// Create an instance of the plugin using the default constructor
-			IPlugin plugin = (IPlugin)Activator.CreateInstance(pluginType);
+			// Create an instance of the plugin
+			IPlugin plugin = (IPlugin)ActivatorProvider.CreateInstance(pluginType);
 
 			return plugin;
 		}

--- a/src/log4net/Config/SecurityContextProviderAttribute.cs
+++ b/src/log4net/Config/SecurityContextProviderAttribute.cs
@@ -112,7 +112,7 @@ namespace log4net.Config
 			{
 				LogLog.Debug(declaringType, "Creating provider of type ["+ m_providerType.FullName +"]");
 
-				SecurityContextProvider provider = Activator.CreateInstance(m_providerType) as SecurityContextProvider;
+				SecurityContextProvider provider = ActivatorProvider.CreateInstance(m_providerType) as SecurityContextProvider;
 
 				if (provider == null)
 				{

--- a/src/log4net/Core/ActivatorProvider.cs
+++ b/src/log4net/Core/ActivatorProvider.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace log4net.Core
+{
+    /// <summary>
+    /// Provider class for <see cref="IActivator"/> instance and methods.
+    /// </summary>
+    /// <author>Travis Schettler</author>
+    public sealed class ActivatorProvider
+    {
+        /// <summary>
+        /// Sets the <see cref="IActivator"/> instance. Default is <see cref="DefaultActivator"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This property is only accessible privately as <see cref="ActivatorProvider"/> contains wrapper methods for the instance, 
+        /// but is allowed to be set to a custom type activator.
+        /// </para>
+        /// </remarks>
+        public static IActivator Instance { private get; set; } = new DefaultActivator();
+
+        /// <summary>
+        /// Wrapper method that calls the <see cref="IActivator.CanCreateInstance(Type)"/> method on the <see cref="Instance"/>.
+        /// </summary>
+		/// <param name="type">The type to inspect.</param>
+		/// <returns><c>true</c> if the type is creatable, <c>false</c> otherwise.</returns>
+        public static bool CanCreateInstance(Type type)
+        {
+           return Instance.CanCreateInstance(type);
+        }
+
+        /// <summary>
+        /// Wrapper method that calls the <see cref="IActivator.CreateInstance(Type)"/> method on the <see cref="Instance"/>.
+        /// </summary>
+        /// <param name="type">The type of service object to get.</param>
+        /// <returns>A service object of the specified type or null if there is no service object for the type.</returns>
+        public static object CreateInstance(Type type)
+        {
+            return Instance.CreateInstance(type);
+        }
+    }
+}

--- a/src/log4net/Core/CompactRepositorySelector.cs
+++ b/src/log4net/Core/CompactRepositorySelector.cs
@@ -243,8 +243,8 @@ namespace log4net.Core
 				{
 					LogLog.Debug(declaringType, "Creating repository ["+repositoryName+"] using type ["+repositoryType+"]");
 
-					// Call the no arg constructor for the repositoryType
-					rep = (ILoggerRepository)Activator.CreateInstance(repositoryType);
+					// Retrieve the repositoryType
+					rep = (ILoggerRepository)ActivatorProvider.CreateInstance(repositoryType);
 
 					// Set the name of the repository
 					rep.Name = repositoryName;

--- a/src/log4net/Core/DefaultActivator.cs
+++ b/src/log4net/Core/DefaultActivator.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Reflection;
+
+namespace log4net.Core
+{
+	/// <summary>
+	/// The default log4net object activator.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Uses <see cref="Activator.CreateInstance(Type)"/> to create instances from types.
+	/// </para>
+	/// </remarks>
+	/// <author>Travis Schettler</author>
+	internal sealed class DefaultActivator : IActivator
+    {
+		/// <summary>
+		/// Test if a <see cref="Type"/> is constructible with <see cref="CreateInstance(Type)"/>.
+		/// </summary>
+		/// <param name="type">the type to inspect</param>
+		/// <returns><c>true</c> if the type is creatable using a default constructor, <c>false</c> otherwise</returns>
+		/// <remarks>
+		/// <para>
+		/// Original code refactored out of the IsTypeConstructible method in the <see cref="Repository.Hierarchy.XmlHierarchyConfigurator"/> class.
+		/// </para>
+		/// </remarks>
+		public bool CanCreateInstance(Type type)
+        {
+#if NETSTANDARD1_3
+			TypeInfo typeInfo = type.GetTypeInfo();
+			if (typeInfo.IsClass && !typeInfo.IsAbstract)
+#else
+			if (type.IsClass && !type.IsAbstract)
+#endif
+			{
+				ConstructorInfo defaultConstructor = type.GetConstructor(new Type[0]);
+				if (defaultConstructor != null && !defaultConstructor.IsAbstract && !defaultConstructor.IsPrivate)
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Creates an instance of the specified type using that type's default constructor.
+		/// </summary>
+		/// <param name="serviceType">The type of object to create.</param>
+		/// <returns>A reference to the newly created object.</returns>
+		public object CreateInstance(Type serviceType)
+        {
+			return Activator.CreateInstance(serviceType);
+		}
+	}
+}

--- a/src/log4net/Core/DefaultRepositorySelector.cs
+++ b/src/log4net/Core/DefaultRepositorySelector.cs
@@ -413,7 +413,7 @@ namespace log4net.Core
 						LogLog.Debug(declaringType, "Creating repository [" + repositoryName + "] using type [" + repositoryType + "]");
 
 						// Call the no arg constructor for the repositoryType
-						rep = (ILoggerRepository)Activator.CreateInstance(repositoryType);
+						rep = (ILoggerRepository)ActivatorProvider.CreateInstance(repositoryType);
 
 						// Set the name of the repository
 						rep.Name = repositoryName;

--- a/src/log4net/Core/IActivator.cs
+++ b/src/log4net/Core/IActivator.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace log4net.Core
+{
+    /// <summary>
+    /// Contains method to create types of objects, or obtain references to existing objects.
+    /// </summary>
+    /// <author>Travis Schettler</author>
+    public interface IActivator
+    {
+        /// <summary>
+		/// Test if a <see cref="Type"/> is constructible with <see cref="CreateInstance(Type)"/>.
+        /// </summary>
+		/// <param name="type">The type to inspect.</param>
+		/// <returns><c>true</c> if the type is creatable, <c>false</c> otherwise.</returns>
+        bool CanCreateInstance(Type type);
+
+        /// <summary>
+        /// Creates an instance of the specified type.
+        /// </summary>
+        /// <param name="type">The type of object to create.</param>
+        /// <returns>A reference to the newly created object.</returns>
+        object CreateInstance(Type type);
+    }
+}

--- a/src/log4net/Core/LoggerManager.cs
+++ b/src/log4net/Core/LoggerManager.cs
@@ -125,7 +125,7 @@ namespace log4net.Core
 					object appRepositorySelectorObj = null;
 					try
 					{
-						appRepositorySelectorObj = Activator.CreateInstance(appRepositorySelectorType);
+						appRepositorySelectorObj = ActivatorProvider.CreateInstance(appRepositorySelectorType);
 					}
 					catch(Exception ex)
 					{

--- a/src/log4net/Repository/Hierarchy/XmlHierarchyConfigurator.cs
+++ b/src/log4net/Repository/Hierarchy/XmlHierarchyConfigurator.cs
@@ -301,9 +301,9 @@ namespace log4net.Repository.Hierarchy
 			try 
 			{
 #if NETSTANDARD1_3
-				IAppender appender = (IAppender)Activator.CreateInstance(SystemInfo.GetTypeFromString(this.GetType().GetTypeInfo().Assembly, typeName, true, true));
+				IAppender appender = (IAppender)ActivatorProvider.CreateInstance(SystemInfo.GetTypeFromString(this.GetType().GetTypeInfo().Assembly, typeName, true, true));
 #else
-				IAppender appender = (IAppender)Activator.CreateInstance(SystemInfo.GetTypeFromString(typeName, true, true));
+				IAppender appender = (IAppender)ActivatorProvider.CreateInstance(SystemInfo.GetTypeFromString(typeName, true, true));
 #endif
 				appender.Name = appenderName;
 
@@ -778,7 +778,7 @@ namespace log4net.Repository.Hierarchy
 					{
 						// No value specified
 						Type defaultObjectType = null;
-						if (IsTypeConstructible(propertyType))
+						if (ActivatorProvider.CanCreateInstance(propertyType))
 						{
 							defaultObjectType = propertyType;
 						}
@@ -845,29 +845,6 @@ namespace log4net.Repository.Hierarchy
 			foreach(XmlNode node in element.ChildNodes)
 			{
 				if (node.NodeType == XmlNodeType.Attribute || node.NodeType == XmlNodeType.Element)
-				{
-					return true;
-				}
-			}
-			return false;
-		}
-
-		/// <summary>
-		/// Test if a <see cref="Type"/> is constructible with <c>Activator.CreateInstance</c>.
-		/// </summary>
-		/// <param name="type">the type to inspect</param>
-		/// <returns><c>true</c> if the type is creatable using a default constructor, <c>false</c> otherwise</returns>
-		private static bool IsTypeConstructible(Type type)
-		{
-#if NETSTANDARD1_3
-			TypeInfo typeInfo = type.GetTypeInfo();
-			if (typeInfo.IsClass && !typeInfo.IsAbstract)
-#else
-			if (type.IsClass && !type.IsAbstract)
-#endif
-			{
-				ConstructorInfo defaultConstructor = type.GetConstructor(new Type[0]);
-				if (defaultConstructor != null && !defaultConstructor.IsAbstract && !defaultConstructor.IsPrivate)
 				{
 					return true;
 				}
@@ -1027,7 +1004,7 @@ namespace log4net.Repository.Hierarchy
 			object createdObject = null;
 			try
 			{
-				createdObject = Activator.CreateInstance(objectType);
+				createdObject = ActivatorProvider.CreateInstance(objectType);
 			}
 			catch(Exception createInstanceEx)
 			{

--- a/src/log4net/Util/OptionConverter.cs
+++ b/src/log4net/Util/OptionConverter.cs
@@ -493,7 +493,7 @@ namespace log4net.Util
 						LogLog.Error(declaringType, "OptionConverter: A [" + className + "] object is not assignable to a [" + superClass.FullName + "] variable.");
 						return defaultValue;	  
 					}
-					return Activator.CreateInstance(classObj);
+					return ActivatorProvider.CreateInstance(classObj);
 				}
 				catch (Exception e) 
 				{

--- a/src/log4net/Util/PatternParser.cs
+++ b/src/log4net/Util/PatternParser.cs
@@ -336,7 +336,7 @@ namespace log4net.Util
 				PatternConverter pc = null;
 				try
 				{
-                    pc = (PatternConverter)Activator.CreateInstance(converterInfo.Type);
+                    pc = (PatternConverter)ActivatorProvider.CreateInstance(converterInfo.Type);
 				}
 				catch(Exception createInstanceEx)
 				{

--- a/src/log4net/Util/TypeConverters/ConverterRegistry.cs
+++ b/src/log4net/Util/TypeConverters/ConverterRegistry.cs
@@ -17,6 +17,7 @@
 //
 #endregion
 
+using log4net.Core;
 using System;
 using System.Collections;
 #if NETSTANDARD1_3
@@ -267,11 +268,11 @@ namespace log4net.Util.TypeConverters
 				try
 				{
 					// Create the type converter
-					return Activator.CreateInstance(converterType);
+					return ActivatorProvider.CreateInstance(converterType);
 				}
 				catch(Exception ex)
 				{
-					LogLog.Error(declaringType, "Cannot CreateConverterInstance of type ["+converterType.FullName+"], Exception in call to Activator.CreateInstance", ex);
+					LogLog.Error(declaringType, "Cannot CreateConverterInstance of type ["+converterType.FullName+"], Exception in call to ActivatorProvider.CreateInstance", ex);
 				}
 			}
 			else


### PR DESCRIPTION
This refactors type activation into an `ActivationProvider` class, which provides wrapper methods for the `IActivator` interface. The default `IActivator` implementation (`DefaultActivator`) derives from the current logic which uses `Activator.CreateInstance`. Clients of log4net can set the IActivator instance to a custom implementation if they so choose. For an example use case, this will allow for dependency injection in custom appenders and pattern converters.

I researched how to do dependency injection in custom log4net appenders and pattern converters without making changes to log4net itself and it proves to be increasingly difficult, since it would require custom classes in cases where Activator.CreateInstance is used. I tried to keep my changes to a bare minimum, as I recognize this project is one of the most popular logging frameworks in .NET and any changes must be heavily scrutinized.

I also recognize that there have been other attempts to add this capability to log4net (#26, #72), but this implementation is merely a refactoring of the existing `Activator.CreateInstance` logic. With all due respect to the authors of the previous implementation attempts, this implementation provides one other key component that the other attempts were missing. The `IsTypeConstructible` method of `XmlHierarchyConfigurator` has been refactored into a `CanCreateInstance` method on the `IActivator` interface. This is necessary to allow custom activation of types without a default constructor.

As this is my first contribution to this project, any feedback is definitely appreciated! 

Thanks!

Travis Schettler