### PR TITLE
Fix Consuming .netstandard in .net4.72

### DIFF
--- a/src/log4net/AssemblyInfo.cs
+++ b/src/log4net/AssemblyInfo.cs
@@ -39,14 +39,13 @@ using System.Runtime.CompilerServices;
 [assembly: System.Security.AllowPartiallyTrustedCallers]
 #endif
 
-#if (NET_4_0)
+#if (NET_4_0 || NETSTANDARD2_0)
 //
 // Allows partial trust applications (e.g. ASP.NET shared hosting) on .NET 4.0 to work
 // given our implementation of ISerializable.
 //
 [assembly: System.Security.SecurityRules(System.Security.SecurityRuleSet.Level1)]
 #endif
-
 //
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information


### PR DESCRIPTION
A small change in AssemblyInfo allows the netstandard2.0 libraries to be used with net4.72 asp.net web services