### PR TITLE
Enforcing TLS 1.2

### DIFF
--- a/install-dotnet-core-sdk-1.1.ps1
+++ b/install-dotnet-core-sdk-1.1.ps1
@@ -1,3 +1,6 @@
+#Enforce TLS 1.2 as Microsoft is deprecating all old TLS versions
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+
 $installer="dotnet-dev-win-x64.1.1.14.exe"
 Write-Host "Downloading $installer"
 Invoke-WebRequest -Uri "https://download.visualstudio.microsoft.com/download/pr/c6b9a396-5e7a-4b91-86f6-f9e8df3bf1dd/6d61addfd6069e404981bede03f8f4f9/$installer" -OutFile $installer

--- a/install-net-framework-sdk-3.5.ps1
+++ b/install-net-framework-sdk-3.5.ps1
@@ -1,3 +1,6 @@
+#Enforce TLS 1.2 as Microsoft is deprecating all old TLS versions
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
+
 if (-not (Test-Path dotnetfx35.exe)) {
     Write-Host "Downloading dotnetfx35.exe"
     Invoke-WebRequest -Uri "https://download.microsoft.com/download/2/0/E/20E90413-712F-438C-988E-FDAA79A8AC3D/dotnetfx35.exe" -OutFile dotnetfx35.exe


### PR DESCRIPTION
Enforce TLS 1.2 in PowerShell Scrips as Microsoft is deprecating all old TLS versions