### PR TITLE
Add Peek() method to ThreadContextStack and LogicalThreadContextStack.

### DIFF
--- a/src/log4net/Util/LogicalThreadContextStack.cs
+++ b/src/log4net/Util/LogicalThreadContextStack.cs
@@ -198,15 +198,35 @@ namespace log4net.Util
 			return new AutoPopStackFrame(contextStack, stack.Count - 1);
 		}
 
-		#endregion Public Methods
+        /// <summary>
+        /// Returns the top context from this stack.
+        /// </summary>
+        /// <returns>The message in the context from the top of this stack.</returns>
+        /// <remarks>
+        /// <para>
+        /// Returns the top context from this stack. If this stack is empty then an
+        /// empty string (not <see langword="null"/>) is returned.
+        /// </para>
+        /// </remarks>
+        public string Peek()
+        {
+            Stack stack = m_stack;
+            if (stack.Count > 0)
+            {
+                return ((StackFrame)stack.Peek()).Message;
+            }
+            return "";
+        }
 
-		#region Internal Methods
+        #endregion Public Methods
 
-		/// <summary>
-		/// Gets the current context information for this stack.
-		/// </summary>
-		/// <returns>The current context information.</returns>
-		internal string GetFullMessage()
+        #region Internal Methods
+
+        /// <summary>
+        /// Gets the current context information for this stack.
+        /// </summary>
+        /// <returns>The current context information.</returns>
+        internal string GetFullMessage()
 		{
 			Stack stack = m_stack;
 			if (stack.Count > 0)

--- a/src/log4net/Util/LogicalThreadContextStack.cs
+++ b/src/log4net/Util/LogicalThreadContextStack.cs
@@ -26,16 +26,16 @@ using log4net.Core;
 namespace log4net.Util
 {
 
-    /// <summary>
+	/// <summary>
 	/// Delegate type used for LogicalThreadContextStack's callbacks.
 	/// </summary>
-    #if NET_2_0 || MONO_2_0 || NETSTANDARD
+	#if NET_2_0 || MONO_2_0 || NETSTANDARD
 	public delegate void TwoArgAction<T1, T2>(T1 t1, T2 t2);
-    #else
+	#else
 	public delegate void TwoArgAction(string t1, LogicalThreadContextStack t2);
-    #endif
+	#endif
 
-        /// <summary>
+		/// <summary>
 	/// Implementation of Stack for the <see cref="log4net.LogicalThreadContext"/>
 	/// </summary>
 	/// <remarks>
@@ -65,7 +65,7 @@ namespace log4net.Util
 		/// </summary>
 		#if NET_2_0 || MONO_2_0 || NETSTANDARD
 		private TwoArgAction<string, LogicalThreadContextStack> m_registerNew;
-                #else
+				#else
 		private TwoArgAction m_registerNew;
 		#endif
 
@@ -83,7 +83,7 @@ namespace log4net.Util
 		/// </remarks>
 		#if NET_2_0 || MONO_2_0 || NETSTANDARD
 		internal LogicalThreadContextStack(string propertyKey, TwoArgAction<string, LogicalThreadContextStack> registerNew)
-                #else
+				#else
 		internal LogicalThreadContextStack(string propertyKey, TwoArgAction registerNew)
 		#endif
 		{
@@ -198,35 +198,35 @@ namespace log4net.Util
 			return new AutoPopStackFrame(contextStack, stack.Count - 1);
 		}
 
-        /// <summary>
-        /// Returns the top context from this stack.
-        /// </summary>
-        /// <returns>The message in the context from the top of this stack.</returns>
-        /// <remarks>
-        /// <para>
-        /// Returns the top context from this stack. If this stack is empty then an
-        /// empty string (not <see langword="null"/>) is returned.
-        /// </para>
-        /// </remarks>
-        public string Peek()
-        {
-            Stack stack = m_stack;
-            if (stack.Count > 0)
-            {
-                return ((StackFrame)stack.Peek()).Message;
-            }
-            return "";
-        }
+		/// <summary>
+		/// Returns the top context from this stack.
+		/// </summary>
+		/// <returns>The message in the context from the top of this stack.</returns>
+		/// <remarks>
+		/// <para>
+		/// Returns the top context from this stack. If this stack is empty then an
+		/// empty string (not <see langword="null"/>) is returned.
+		/// </para>
+		/// </remarks>
+		public string Peek()
+		{
+			Stack stack = m_stack;
+			if (stack.Count > 0)
+			{
+				return ((StackFrame)stack.Peek()).Message;
+			}
+			return "";
+		}
 
-        #endregion Public Methods
+		#endregion Public Methods
 
-        #region Internal Methods
+		#region Internal Methods
 
-        /// <summary>
-        /// Gets the current context information for this stack.
-        /// </summary>
-        /// <returns>The current context information.</returns>
-        internal string GetFullMessage()
+		/// <summary>
+		/// Gets the current context information for this stack.
+		/// </summary>
+		/// <returns>The current context information.</returns>
+		internal string GetFullMessage()
 		{
 			Stack stack = m_stack;
 			if (stack.Count > 0)

--- a/src/log4net/Util/LogicalThreadContextStack.cs
+++ b/src/log4net/Util/LogicalThreadContextStack.cs
@@ -35,7 +35,7 @@ namespace log4net.Util
 	public delegate void TwoArgAction(string t1, LogicalThreadContextStack t2);
 	#endif
 
-		/// <summary>
+	/// <summary>
 	/// Implementation of Stack for the <see cref="log4net.LogicalThreadContext"/>
 	/// </summary>
 	/// <remarks>
@@ -65,7 +65,7 @@ namespace log4net.Util
 		/// </summary>
 		#if NET_2_0 || MONO_2_0 || NETSTANDARD
 		private TwoArgAction<string, LogicalThreadContextStack> m_registerNew;
-				#else
+		#else
 		private TwoArgAction m_registerNew;
 		#endif
 
@@ -83,7 +83,7 @@ namespace log4net.Util
 		/// </remarks>
 		#if NET_2_0 || MONO_2_0 || NETSTANDARD
 		internal LogicalThreadContextStack(string propertyKey, TwoArgAction<string, LogicalThreadContextStack> registerNew)
-				#else
+		#else
 		internal LogicalThreadContextStack(string propertyKey, TwoArgAction registerNew)
 		#endif
 		{

--- a/src/log4net/Util/ThreadContextStack.cs
+++ b/src/log4net/Util/ThreadContextStack.cs
@@ -159,6 +159,26 @@ namespace log4net.Util
 			return new AutoPopStackFrame(stack, stack.Count - 1);
 		}
 
+        /// <summary>
+        /// Returns the top context from this stack.
+        /// </summary>
+        /// <returns>The message in the context from the top of this stack.</returns>
+        /// <remarks>
+        /// <para>
+        /// Returns the top context from this stack. If this stack is empty then an
+        /// empty string (not <see langword="null"/>) is returned.
+        /// </para>
+        /// </remarks>
+        public string Peek()
+		{
+            Stack stack = m_stack;
+            if (stack.Count > 0)
+            {
+                return ((StackFrame)stack.Peek()).Message;
+            }
+            return "";
+        }
+
 		#endregion Public Methods
 
 		#region Internal Methods

--- a/src/log4net/Util/ThreadContextStack.cs
+++ b/src/log4net/Util/ThreadContextStack.cs
@@ -159,25 +159,25 @@ namespace log4net.Util
 			return new AutoPopStackFrame(stack, stack.Count - 1);
 		}
 
-        /// <summary>
-        /// Returns the top context from this stack.
-        /// </summary>
-        /// <returns>The message in the context from the top of this stack.</returns>
-        /// <remarks>
-        /// <para>
-        /// Returns the top context from this stack. If this stack is empty then an
-        /// empty string (not <see langword="null"/>) is returned.
-        /// </para>
-        /// </remarks>
-        public string Peek()
+		/// <summary>
+		/// Returns the top context from this stack.
+		/// </summary>
+		/// <returns>The message in the context from the top of this stack.</returns>
+		/// <remarks>
+		/// <para>
+		/// Returns the top context from this stack. If this stack is empty then an
+		/// empty string (not <see langword="null"/>) is returned.
+		/// </para>
+		/// </remarks>
+		public string Peek()
 		{
-            Stack stack = m_stack;
-            if (stack.Count > 0)
-            {
-                return ((StackFrame)stack.Peek()).Message;
-            }
-            return "";
-        }
+			Stack stack = m_stack;
+			if (stack.Count > 0)
+			{
+				return ((StackFrame)stack.Peek()).Message;
+			}
+			return "";
+		}
 
 		#endregion Public Methods
 


### PR DESCRIPTION
**Change**
Add `Peek()` method to `ThreadContextStack` and `LogicalThreadContextStack` to be able to get the most recent value from the context without removing it.

**Motivation**
In the scope of [ElasticCommonSchema .NET integration for log4net](https://github.com/elastic/ecs-dotnet/tree/main/src/Elastic.CommonSchema.Log4net) log entry properties are being read and written to ECS format. In case of context stacks [current implementation](https://github.com/elastic/ecs-dotnet/blob/main/src/Elastic.CommonSchema.Log4net/LoggingEventConverter.cs#L85) takes string representation of the stack. It works fine when stack (i.e., property) has a single value, but there are also cases when stack contains multiple values (same or different ones). With the proposed changes it will be able to take the most recent value, in the context of which the current log entry is being written.

Consider following scenario:

```cs
using (LogicalThreadContext.Stacks["Id"].Push("123"))
{
    log.Info("Log 1"); // currently has "123" in the log metadata

    using (LogicalThreadContext.Stacks["Id"].Push("456"))
    {
        log.Info("Log 2"); // currently has "123 456" in the log metadata; should have "456" instead

        using (LogicalThreadContext.Stacks["Id"].Push("789"))
        {
            log.Info("Log 3"); // currently has "123 456 789" in the log metadata; should have "789" instead
        }
    }
}
```

**Alternative solutions considered**
An alternative approach might be to just pop the most recent value and then push it again onto the stack. Problem here is that it creates a new scope which will not be closed as no one will call `Dispose()` on the returned result from `Push()`.