### PR TITLE
Fix thread name compatibility with .net 8

### DIFF
--- a/src/log4net/Core/LoggingEvent.cs
+++ b/src/log4net/Core/LoggingEvent.cs
@@ -737,9 +737,10 @@ namespace log4net.Core
  SystemInfo.CurrentThreadId.ToString(System.Globalization.NumberFormatInfo.InvariantInfo);
 #else
                     // '.NET ThreadPool Worker' appears as a default thread pool name in .NET 6+.
+                    // '.NET TP Worker' appears as a default thread pool name in .NET 8+.
                     // Prefer the numeric thread ID instead.
                     string threadName = System.Threading.Thread.CurrentThread.Name;
-                    if (!string.IsNullOrEmpty(threadName) && threadName != ".NET ThreadPool Worker")
+                    if (!string.IsNullOrEmpty(threadName) && threadName != ".NET ThreadPool Worker" && threadName != ".NET TP Worker")
                     {
                         m_data.ThreadName = threadName;
                     }


### PR DESCRIPTION
The thread name changed in .net 8, this keeps compatibility with .net 8,
see https://github.com/apache/logging-log4net/commit/a17282a45509cd8d23695ded3938958cfe21ccd0 for details.