### PR TITLE
Fix CodeQL Password in configuration file Rule False Positives

### DIFF
--- a/examples/mono/1.0/Tutorials/ConsoleApp/cs/src/App.config
+++ b/examples/mono/1.0/Tutorials/ConsoleApp/cs/src/App.config
@@ -145,7 +145,7 @@
         <appender name="ADONetAppender_SqlServer" type="log4net.Appender.AdoNetAppender">
             <bufferSize value="1" />
             <connectionType value="System.Data.SqlClient.SqlConnection, System.Data, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-            <connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;User ID=sa;Password=sa" />
+            <connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;" />
             <commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message]) VALUES (@log_date, @thread, @log_level, @logger, @message)" />
             <parameter>
                 <parameterName value="@log_date" />

--- a/examples/net/1.1/Tutorials/ConsoleApp/cpp/src/App.config
+++ b/examples/net/1.1/Tutorials/ConsoleApp/cpp/src/App.config
@@ -150,7 +150,7 @@
 		<appender name="ADONetAppender_SqlServer" type="log4net.Appender.AdoNetAppender">
 			<bufferSize value="1" />
 			<connectionType value="System.Data.SqlClient.SqlConnection, System.Data, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;User ID=sa;Password=sa" />
+			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;" />
 			<commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message]) VALUES (@log_date, @thread, @log_level, @logger, @message)" />
 			<parameter>
 				<parameterName value="@log_date" />

--- a/examples/net/1.1/Tutorials/ConsoleApp/js/src/App.config
+++ b/examples/net/1.1/Tutorials/ConsoleApp/js/src/App.config
@@ -150,7 +150,7 @@
 		<appender name="ADONetAppender_SqlServer" type="log4net.Appender.AdoNetAppender">
 			<bufferSize value="1" />
 			<connectionType value="System.Data.SqlClient.SqlConnection, System.Data, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;User ID=sa;Password=sa" />
+			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;" />
 			<commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message]) VALUES (@log_date, @thread, @log_level, @logger, @message)" />
 			<parameter>
 				<parameterName value="@log_date" />

--- a/examples/net/2.0/Appenders/SampleAppendersApp/cs/src/App.config
+++ b/examples/net/2.0/Appenders/SampleAppendersApp/cs/src/App.config
@@ -96,7 +96,7 @@
 		</appender>
 		
 		<appender name="FastDbAppender" type="SampleAppendersApp.Appender.FastDbAppender, SampleAppendersApp">
-			<connectionString value="Persist Security Info=False;Integrated Security=false;server=ate;database=log4net_test;Connect Timeout=30;User ID=sa;Password=sa" />
+			<connectionString value="Persist Security Info=False;Integrated Security=false;server=ate;database=log4net_test;Connect Timeout=30;" />
 		</appender>
 		
 		<appender name="PatternFileAppender" type="SampleAppendersApp.Appender.PatternFileAppender, SampleAppendersApp">

--- a/examples/net/2.0/Tutorials/ConsoleApp/cs/src/App.config
+++ b/examples/net/2.0/Tutorials/ConsoleApp/cs/src/App.config
@@ -150,7 +150,7 @@
 		<appender name="ADONetAppender_SqlServer" type="log4net.Appender.AdoNetAppender">
 			<bufferSize value="1" />
 			<connectionType value="System.Data.SqlClient.SqlConnection, System.Data, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;User ID=sa;Password=sa" />
+			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;" />
 			<commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message]) VALUES (@log_date, @thread, @log_level, @logger, @message)" />
 			<parameter>
 				<parameterName value="@log_date" />

--- a/examples/net/2.0/Tutorials/ConsoleApp/vb/src/App.config
+++ b/examples/net/2.0/Tutorials/ConsoleApp/vb/src/App.config
@@ -150,7 +150,7 @@
 		<appender name="ADONetAppender_SqlServer" type="log4net.Appender.AdoNetAppender">
 			<bufferSize value="1" />
 			<connectionType value="System.Data.SqlClient.SqlConnection, System.Data, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;User ID=sa;Password=sa" />
+			<connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;" />
 			<commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message]) VALUES (@log_date, @thread, @log_level, @logger, @message)" />
 			<parameter>
 				<parameterName value="@log_date" />

--- a/src/log4net/Appender/AdoNetAppender.cs
+++ b/src/log4net/Appender/AdoNetAppender.cs
@@ -89,7 +89,7 @@ namespace log4net.Appender
 	/// <code lang="XML" escaped="true">
 	/// <appender name="AdoNetAppender_SqlServer" type="log4net.Appender.AdoNetAppender" >
 	///   <connectionType value="System.Data.SqlClient.SqlConnection, System.Data, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-	///   <connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;User ID=sa;Password=sa" />
+	///   <connectionString value="data source=SQLSVR;initial catalog=test_log4net;integrated security=false;persist security info=True;" />
 	///   <commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message]) VALUES (@log_date, @thread, @log_level, @logger, @message)" />
 	///   <parameter>
 	///     <parameterName value="@log_date" />


### PR DESCRIPTION
CodeQL is falsly identifying the documentation examples of SQL Server connection strings violating [CodeQL: c# Password in configuration file Rule](https://codeql.github.com/codeql-query-help/csharp/cs-password-in-configuration/). Even though it's a false positive, many organizations take stances of not allowing dismissals and would rather see fixes for CodeQL findings. This proposed change will prevent this rule from being tripped in the future and not require organizations to mark these as false positives manually.