### PR TITLE
Enable nullable for FileAppender, RollingFileAppender, and unit tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+indent_style = space
+indent_size = 2

--- a/.github/workflows/git-broadcast.yml
+++ b/.github/workflows/git-broadcast.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         git config --global user.name "Git Broadcast"
         git config --global user.email "git-broadcast@no-reply.com"
-        npx git-broadcast@latest --from master --push --pretty --suppress-log-prefixes --prefix-logs-with $GITHUB_REPOSITORY
+        npx git-broadcast@beta --ignore abandoned-develop --from master --push --pretty --suppress-log-prefixes --prefix-logs-with $GITHUB_REPOSITORY

--- a/.github/workflows/git-broadcast.yml
+++ b/.github/workflows/git-broadcast.yml
@@ -19,7 +19,6 @@ jobs:
         node-version: '16'
     - name: broadcast master changes to satellite branches
       env:
-        DEBUG: '*'
         RUN_NUMBER: ${{ github.run_number }}
       run: |
         git config --global user.name "Git Broadcast"

--- a/.github/workflows/git-broadcast.yml
+++ b/.github/workflows/git-broadcast.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: '16'
     - name: broadcast master changes to satellite branches
       env:
-        DEBUG: *
+        DEBUG: '*'
         RUN_NUMBER: ${{ github.run_number }}
       run: |
         git config --global user.name "Git Broadcast"

--- a/.github/workflows/git-broadcast.yml
+++ b/.github/workflows/git-broadcast.yml
@@ -19,6 +19,7 @@ jobs:
         node-version: '16'
     - name: broadcast master changes to satellite branches
       env:
+        DEBUG: *
         RUN_NUMBER: ${{ github.run_number }}
       run: |
         git config --global user.name "Git Broadcast"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
         <UseSharedCompilation>true</UseSharedCompilation>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 </Project>

--- a/src/integration-testing/log4net-611-lib/log4net-611-lib.csproj
+++ b/src/integration-testing/log4net-611-lib/log4net-611-lib.csproj
@@ -5,7 +5,6 @@
     <RootNamespace>log4net_611_lib</RootNamespace>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/integration-testing/log4net-611-main/log4net-611-main.csproj
+++ b/src/integration-testing/log4net-611-main/log4net-611-main.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>log4net_611_main</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/log4net.Tests/Appender/EventLogAppenderTest.cs
+++ b/src/log4net.Tests/Appender/EventLogAppenderTest.cs
@@ -51,54 +51,44 @@ namespace log4net.Tests.Appender
 
       Assert.AreEqual(
         EventLogEntryType.Information,
-        GetEntryType(eventAppender, Level.All));
+        eventAppender.GetEntryType(Level.All));
 
       Assert.AreEqual(
         EventLogEntryType.Information,
-        GetEntryType(eventAppender, Level.Debug));
+        eventAppender.GetEntryType(Level.Debug));
 
       Assert.AreEqual(
         EventLogEntryType.Information,
-        GetEntryType(eventAppender, Level.Info));
+        eventAppender.GetEntryType(Level.Info));
 
       Assert.AreEqual(
         EventLogEntryType.Warning,
-        GetEntryType(eventAppender, Level.Warn));
+        eventAppender.GetEntryType(Level.Warn));
 
       Assert.AreEqual(
         EventLogEntryType.Error,
-        GetEntryType(eventAppender, Level.Error));
+        eventAppender.GetEntryType(Level.Error));
 
       Assert.AreEqual(
         EventLogEntryType.Error,
-        GetEntryType(eventAppender, Level.Fatal));
+        eventAppender.GetEntryType(Level.Fatal));
 
       Assert.AreEqual(
         EventLogEntryType.Error,
-        GetEntryType(eventAppender, Level.Off));
+        eventAppender.GetEntryType(Level.Off));
     }
 
     /// <summary>
     /// ActivateOption tries to create an event source if it doesn't exist but this is going to fail on more modern Windows versions unless the code is run with local administrator privileges.
     /// </summary>
     [Test]
-    [Ignore("seems to require administrator privileges or a specific environent when run")]
+    [Ignore("seems to require administrator privileges or a specific environment when run")]
     public void ActivateOptionsDisablesAppenderIfSourceDoesntExist()
     {
       EventLogAppender eventAppender = new EventLogAppender();
       eventAppender.ActivateOptions();
       Assert.AreEqual(Level.Off, eventAppender.Threshold);
     }
-
-    //
-    // Helper functions to dig into the appender
-    //
-
-    private static EventLogEntryType GetEntryType(EventLogAppender appender, Level level)
-    {
-      return (EventLogEntryType)Utils.InvokeMethod(appender, "GetEntryType", level);
-    }
-
   }
 }
 

--- a/src/log4net.Tests/Appender/RemotingAppenderTest.cs
+++ b/src/log4net.Tests/Appender/RemotingAppenderTest.cs
@@ -101,7 +101,7 @@ namespace log4net.Tests.Appender
       Assert.AreEqual(1, events.Length, "Expect to receive 1 remoted event");
 
       // Grab the event data
-      LoggingEventData eventData = GetLoggingEventData(events[0]);
+      LoggingEventData eventData = events[0].m_data;
 
       Assert.IsNull(eventData.LocationInfo, "Expect LocationInfo to be null because only doing a partial fix");
     }
@@ -131,7 +131,7 @@ namespace log4net.Tests.Appender
       Assert.AreEqual(1, events.Length, "Expect to receive 1 remoted event");
 
       // Grab the event data
-      LoggingEventData eventData = GetLoggingEventData(events[0]);
+      LoggingEventData eventData = events[0].m_data;
 
       Assert.IsNotNull(eventData.LocationInfo, "Expect LocationInfo to not be null because doing a full fix");
     }
@@ -376,15 +376,6 @@ namespace log4net.Tests.Appender
       {
         get { return (LoggingEvent[])m_events.ToArray(typeof(LoggingEvent)); }
       }
-    }
-
-    //
-    // Helper functions to dig into the appender
-    //
-
-    private static LoggingEventData GetLoggingEventData(LoggingEvent loggingEvent)
-    {
-      return (LoggingEventData)Utils.GetField(loggingEvent, "m_data");
     }
   }
 }

--- a/src/log4net.Tests/Appender/RemotingAppenderTest.cs
+++ b/src/log4net.Tests/Appender/RemotingAppenderTest.cs
@@ -100,10 +100,7 @@ namespace log4net.Tests.Appender
       LoggingEvent[] events = RemoteLoggingSinkImpl.Instance.Events;
       Assert.AreEqual(1, events.Length, "Expect to receive 1 remoted event");
 
-      // Grab the event data
-      LoggingEventData eventData = events[0].m_data;
-
-      Assert.IsNull(eventData.LocationInfo, "Expect LocationInfo to be null because only doing a partial fix");
+      Assert.IsNull(events[0].LocationInfo, "Expect LocationInfo to be null because only doing a partial fix");
     }
 
     /// <summary>
@@ -130,10 +127,7 @@ namespace log4net.Tests.Appender
       LoggingEvent[] events = RemoteLoggingSinkImpl.Instance.Events;
       Assert.AreEqual(1, events.Length, "Expect to receive 1 remoted event");
 
-      // Grab the event data
-      LoggingEventData eventData = events[0].m_data;
-
-      Assert.IsNotNull(eventData.LocationInfo, "Expect LocationInfo to not be null because doing a full fix");
+      Assert.IsNotNull(events[0].LocationInfo, "Expect LocationInfo to not be null because doing a full fix");
     }
 
     private void WaitFor(
@@ -145,9 +139,7 @@ namespace log4net.Tests.Appender
       do
       {
         if (condition())
-        {
           return;
-        }
         Thread.Sleep(100);
       } while ((DateTime.Now - start).TotalMilliseconds < maxWaitMilliseconds);
       throw new TimeoutException($"Condition not achieved within {maxWaitMilliseconds}ms: {failMessage}");

--- a/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
+++ b/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
@@ -86,6 +86,15 @@ namespace log4net.Tests.Appender
       }
     }
 
+    private sealed class RollingFileAppenderForTest : RollingFileAppender
+    {
+      /// <summary>
+      /// Builds a list of filenames for all files matching the base filename plus a file pattern.
+      /// </summary>
+      internal new List<string> GetExistingFiles(string baseFilePath)
+        => base.GetExistingFiles(baseFilePath);
+    }
+
     /// <summary>
     /// Sets up variables used for the tests
     /// </summary>
@@ -1927,7 +1936,7 @@ namespace log4net.Tests.Appender
 
     private static List<string> GetExistingFiles(string baseFilePath, bool preserveLogFileNameExtension = false)
     {
-      RollingFileAppender appender = new RollingFileAppender
+      RollingFileAppenderForTest appender = new()
       {
         PreserveLogFileNameExtension = preserveLogFileNameExtension,
         SecurityContext = NullSecurityContext.Instance
@@ -1937,17 +1946,12 @@ namespace log4net.Tests.Appender
 
     private static string GetTestMessage()
     {
-      switch (Environment.NewLine.Length)
+      return Environment.NewLine.Length switch
       {
-        case 2:
-          return c_testMessage98Chars;
-
-        case 1:
-          return c_testMessage99Chars;
-
-        default:
-          throw new Exception("Unexpected Environment.NewLine.Length");
-      }
+        2 => c_testMessage98Chars,
+        1 => c_testMessage99Chars,
+        _ => throw new Exception("Unexpected Environment.NewLine.Length"),
+      };
     }
   }
 

--- a/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
+++ b/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
@@ -1307,7 +1307,7 @@ namespace log4net.Tests.Appender
         int iExpectedValue)
     {
       rfa.InitializeRollBackups(sBaseFile, alFiles);
-      Assert.AreEqual(iExpectedValue, rfa.m_curSizeRollBackups);
+      Assert.AreEqual(iExpectedValue, rfa.CurrentSizeRollBackups);
     }
 
     /// <summary>
@@ -1343,7 +1343,7 @@ namespace log4net.Tests.Appender
       RollingFileAppender rfa = new RollingFileAppender();
       rfa.RollingStyle = RollingFileAppender.RollingMode.Size;
       rfa.MaxSizeRollBackups = Int32.Parse(asParams[0].Trim());
-      rfa.m_curSizeRollBackups = Int32.Parse(asParams[1].Trim());
+      rfa.CurrentSizeRollBackups = Int32.Parse(asParams[1].Trim());
       rfa.CountDirection = Int32.Parse(asParams[2].Trim());
 
       return rfa;
@@ -1869,17 +1869,14 @@ namespace log4net.Tests.Appender
     private void VerifyInitializeRollBackups(int iBackups, int iMaxSizeRollBackups)
     {
       string sBaseFile = "LogFile.log";
-      var arrFiles = new List<string>();
-      arrFiles.Add("junk1");
+      var arrFiles = new List<string> { "junk1" };
       for (int i = 0; i < iBackups; i++)
-      {
         arrFiles.Add(MakeFileName(sBaseFile, i));
-      }
 
-      RollingFileAppender rfa = new RollingFileAppender();
+      RollingFileAppender rfa = new();
       rfa.RollingStyle = RollingFileAppender.RollingMode.Size;
       rfa.MaxSizeRollBackups = iMaxSizeRollBackups;
-      rfa.m_curSizeRollBackups = 0;
+      rfa.CurrentSizeRollBackups = 0;
       rfa.InitializeRollBackups(sBaseFile, arrFiles);
 
       // iBackups  / Meaning
@@ -1887,15 +1884,10 @@ namespace log4net.Tests.Appender
       // 1 = file.log
       // 2 = file.log.1
       // 3 = file.log.2
-      if (0 == iBackups ||
-          1 == iBackups)
-      {
-        Assert.AreEqual(0, rfa.m_curSizeRollBackups);
-      }
+      if (iBackups is 0 or 1)
+        Assert.AreEqual(0, rfa.CurrentSizeRollBackups);
       else
-      {
-        Assert.AreEqual(Math.Min(iBackups - 1, iMaxSizeRollBackups), rfa.m_curSizeRollBackups);
-      }
+        Assert.AreEqual(Math.Min(iBackups - 1, iMaxSizeRollBackups), rfa.CurrentSizeRollBackups);
     }
 
     /// <summary>
@@ -1925,8 +1917,8 @@ namespace log4net.Tests.Appender
     [Test]
     public void TestCreateCloseNoActivateOptions()
     {
-        var appender = new RollingFileAppender();
-        appender.Close();
+      var appender = new RollingFileAppender();
+      appender.Close();
     }
 
     //
@@ -1937,8 +1929,8 @@ namespace log4net.Tests.Appender
     {
       RollingFileAppender appender = new RollingFileAppender
       {
-          PreserveLogFileNameExtension = preserveLogFileNameExtension,
-          SecurityContext = NullSecurityContext.Instance
+        PreserveLogFileNameExtension = preserveLogFileNameExtension,
+        SecurityContext = NullSecurityContext.Instance
       };
       return appender.GetExistingFiles(baseFilePath);
     }

--- a/src/log4net.Tests/Context/ThreadContextTest.cs
+++ b/src/log4net.Tests/Context/ThreadContextTest.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using log4net.Config;
 using log4net.Layout;
@@ -28,8 +29,6 @@ using log4net.Repository;
 using log4net.Tests.Appender;
 using log4net.Util;
 using NUnit.Framework;
-using static NExpect.Expectations;
-using NExpect;
 
 namespace log4net.Tests.Context
 {
@@ -252,9 +251,7 @@ namespace log4net.Tests.Context
         t.Join();
       }
 
-      // Assert
-      Expect(flags)
-          .To.Contain.All.Matched.By(o => o.Flag == false);
+      Assert.IsTrue(flags.All(o => !o.Flag));
     }
 
     public class FlagContainer

--- a/src/log4net.Tests/Core/FixingTest.cs
+++ b/src/log4net.Tests/Core/FixingTest.cs
@@ -24,13 +24,9 @@ using System.Threading;
 using log4net.Core;
 
 using NUnit.Framework;
-using static NExpect.Expectations;
-using NExpect;
 
 namespace log4net.Tests.Core
 {
-  /// <summary>
-  /// </<summary>
   [TestFixture]
   public class FixingTest
   {
@@ -75,8 +71,7 @@ namespace log4net.Tests.Core
       // Assert
       foreach (var flag in allFlags)
       {
-        Expect(FixFlags.All & flag)
-          .To.Equal(flag, () => $"FixFlags.All does not contain {flag}");
+        Assert.AreEqual(flag, FixFlags.All & flag, $"FixFlags.All does not contain {flag}");
       }
     }
 

--- a/src/log4net.Tests/Signing.cs
+++ b/src/log4net.Tests/Signing.cs
@@ -1,7 +1,5 @@
 ﻿using log4net.Repository;
 using NUnit.Framework;
-using NExpect;
-using static NExpect.Expectations;
 
 namespace log4net.Tests
 {
@@ -15,9 +13,7 @@ namespace log4net.Tests
       var asm = typeof(LoggerRepositorySkeleton).Assembly;
       // Act
       var result = asm.GetName().GetPublicKey();
-      // Assert
-      Expect(result)
-          .Not.To.Be.Empty();
+      Assert.AreNotEqual(0, result.Length);
     }
   }
 }

--- a/src/log4net.Tests/Util/EnvironmentPatternConverterTest.cs
+++ b/src/log4net.Tests/Util/EnvironmentPatternConverterTest.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.IO;
+using log4net.Util.PatternStringConverters;
 using NUnit.Framework;
 
 namespace log4net.Tests.Util
@@ -86,27 +87,6 @@ namespace log4net.Tests.Util
       Assert.AreEqual(PROCESS_LEVEL_VALUE, sw.ToString(), "Process level environment variable not expended correctly.");
 
       Environment.SetEnvironmentVariable(ENVIRONMENT_VARIABLE_NAME, null);
-    }
-
-    private sealed class EnvironmentPatternConverter
-    {
-      private object target = null;
-
-      public EnvironmentPatternConverter()
-      {
-        target = Utils.CreateInstance("log4net.Util.PatternStringConverters.EnvironmentPatternConverter,log4net");
-      }
-
-      public string Option
-      {
-        get { return Utils.GetProperty(target, "Option") as string; }
-        set { Utils.SetProperty(target, "Option", value); }
-      }
-
-      public void Convert(TextWriter writer, object state)
-      {
-        Utils.InvokeMethod(target, "Convert", writer, state);
-      }
     }
   }
 }

--- a/src/log4net.Tests/Util/PatternConverterTest.cs
+++ b/src/log4net.Tests/Util/PatternConverterTest.cs
@@ -131,62 +131,33 @@ namespace log4net.Tests.Util
   {
     private static PropertyKeyCountPatternLayoutConverter mostRecentInstance;
 
-    public PropertyKeyCountPatternLayoutConverter()
-    {
-      mostRecentInstance = this;
-    }
+    public PropertyKeyCountPatternLayoutConverter() => mostRecentInstance = this;
 
-    protected override void Convert(TextWriter writer, LoggingEvent loggingEvent)
-    {
-      writer.Write(Properties.GetKeys().Length);
-    }
+    protected override void Convert(TextWriter writer, LoggingEvent loggingEvent) => writer.Write(Properties.GetKeys().Length);
 
-    public static PropertyKeyCountPatternLayoutConverter MostRecentInstance
-    {
-      get { return mostRecentInstance; }
-    }
+    public static PropertyKeyCountPatternLayoutConverter MostRecentInstance => mostRecentInstance;
   }
 
   public class PropertyKeyCountPatternConverter : PatternConverter
   {
     private static PropertyKeyCountPatternConverter mostRecentInstance;
 
-    public PropertyKeyCountPatternConverter()
-    {
-      mostRecentInstance = this;
-    }
+    public PropertyKeyCountPatternConverter() => mostRecentInstance = this;
 
-    protected internal override void Convert(TextWriter writer, object state)
-    {
-      writer.Write(Properties.GetKeys().Length);
-    }
+    public override void Convert(TextWriter writer, object state)
+      => writer.Write(Properties.GetKeys().Length);
 
-    public static PropertyKeyCountPatternConverter MostRecentInstance
-    {
-      get { return mostRecentInstance; }
-    }
+    public static PropertyKeyCountPatternConverter MostRecentInstance => mostRecentInstance;
   }
 
   public class PatternStringAppender : StringAppender
   {
     private static PatternStringAppender mostRecentInstace;
 
-    private PatternString setting;
+    public PatternStringAppender() => mostRecentInstace = this;
 
-    public PatternStringAppender()
-    {
-      mostRecentInstace = this;
-    }
+    public PatternString Setting { get; set; }
 
-    public PatternString Setting
-    {
-      get { return setting; }
-      set { setting = value; }
-    }
-
-    public static PatternStringAppender MostRecentInstace
-    {
-      get { return mostRecentInstace; }
-    }
+    public static PatternStringAppender MostRecentInstace => mostRecentInstace;
   }
 }

--- a/src/log4net.Tests/Util/PatternConverterTest.cs
+++ b/src/log4net.Tests/Util/PatternConverterTest.cs
@@ -156,7 +156,7 @@ namespace log4net.Tests.Util
       mostRecentInstance = this;
     }
 
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       writer.Write(Properties.GetKeys().Length);
     }

--- a/src/log4net.Tests/Util/RandomStringPatternConverterTest.cs
+++ b/src/log4net.Tests/Util/RandomStringPatternConverterTest.cs
@@ -18,7 +18,7 @@
 #endregion
 
 using System.IO;
-
+using log4net.Util.PatternStringConverters;
 using NUnit.Framework;
 
 namespace log4net.Tests.Util
@@ -59,32 +59,6 @@ namespace log4net.Tests.Util
 
       string string2 = sw.ToString();
       Assert.IsTrue(string1 != string2, "strings should be different");
-    }
-
-    private class RandomStringPatternConverter
-    {
-      private object target = null;
-
-      public RandomStringPatternConverter()
-      {
-        target = Utils.CreateInstance("log4net.Util.PatternStringConverters.RandomStringPatternConverter,log4net");
-      }
-
-      public string Option
-      {
-        get { return Utils.GetProperty(target, "Option") as string; }
-        set { Utils.SetProperty(target, "Option", value); }
-      }
-
-      public void Convert(TextWriter writer, object state)
-      {
-        Utils.InvokeMethod(target, "Convert", writer, state);
-      }
-
-      public void ActivateOptions()
-      {
-        Utils.InvokeMethod(target, "ActivateOptions");
-      }
     }
   }
 }

--- a/src/log4net.Tests/Utils.cs
+++ b/src/log4net.Tests/Utils.cs
@@ -18,89 +18,14 @@
 #endregion
 
 using log4net.Repository;
-using System;
-using System.Reflection;
 
 namespace log4net.Tests
 {
   /// <summary>
   /// Summary description for Class1.
   /// </summary>
-  public class Utils
+  public static class Utils
   {
-    private Utils()
-    {
-    }
-
-    public static object CreateInstance(string targetType)
-    {
-      return CreateInstance(Type.GetType(targetType, true, true));
-    }
-
-    public static object CreateInstance(Type targetType)
-    {
-      return targetType.GetConstructor(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance, null, Type.EmptyTypes, null).Invoke(null);
-    }
-
-    public static object InvokeMethod(object target, string name, params object[] args)
-    {
-      return target.GetType().GetMethod(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance, null, GetTypesArray(args), null).Invoke(target, args);
-    }
-
-    public static object InvokeMethod(Type target, string name, params object[] args)
-    {
-      return target.GetMethod(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static, null, GetTypesArray(args), null).Invoke(null, args);
-    }
-
-    public static object GetField(object target, string name)
-    {
-      return target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance).GetValue(target);
-    }
-
-    public static void SetField(object target, string name, object val)
-    {
-      target.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance).SetValue(target, val);
-    }
-
-    public static object GetProperty(object target, string name)
-    {
-      return target.GetType().GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance).GetValue(target, null);
-    }
-
-    public static void SetProperty(object target, string name, object val)
-    {
-      target.GetType().GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance).SetValue(target, val, null);
-    }
-
-    public static object GetProperty(object target, string name, params object[] index)
-    {
-      return target.GetType().GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance).GetValue(target, index);
-    }
-
-    public static void SetProperty(object target, string name, object val, params object[] index)
-    {
-      target.GetType().GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance).SetValue(target, val, index);
-    }
-
-    private static Type[] GetTypesArray(object[] args)
-    {
-      Type[] types = new Type[args.Length];
-
-      for (int i = 0; i < args.Length; i++)
-      {
-        if (args[i] == null)
-        {
-          types[i] = typeof(object);
-        }
-        else
-        {
-          types[i] = args[i].GetType();
-        }
-      }
-
-      return types;
-    }
-
     internal const string PROPERTY_KEY = "prop1";
 
     internal static void RemovePropertyFromAllContexts()

--- a/src/log4net.Tests/log4net.Tests.csproj
+++ b/src/log4net.Tests/log4net.Tests.csproj
@@ -65,7 +65,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NExpect" Version="2.0.78" />
     <PackageReference Include="Quackers.TestLogger" Version="1.0.24" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">

--- a/src/log4net.Tests/log4net.Tests.csproj
+++ b/src/log4net.Tests/log4net.Tests.csproj
@@ -30,6 +30,8 @@
     <Deterministic>true</Deterministic>
     <!-- suppress analyzer mismatch warning -->
     <NoWarn>CS8032</NoWarn>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\log4net.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <BaseAddress>285212672</BaseAddress>

--- a/src/log4net.Tests/log4net.Tests.csproj
+++ b/src/log4net.Tests/log4net.Tests.csproj
@@ -23,27 +23,18 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyOriginatorKeyFile>..\..\log4net.snk</AssemblyOriginatorKeyFile>
     <OutputPath>bin\$(Configuration)</OutputPath>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
     <Deterministic>true</Deterministic>
     <!-- suppress analyzer mismatch warning -->
     <NoWarn>CS8032</NoWarn>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\log4net.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup>
     <BaseAddress>285212672</BaseAddress>
     <FileAlignment>4096</FileAlignment>
     <RegisterForComInterop>false</RegisterForComInterop>
     <RemoveIntegerChecks>false</RemoveIntegerChecks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net462'">
-    <DefineConstants>$(DefineConstants);NET_2_0;NET_4_0;NET_4_5</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DefineConstants>TRACE;DEBUG;$(DefineConstants)</DefineConstants>

--- a/src/log4net.Tests/log4net.Tests.csproj
+++ b/src/log4net.Tests/log4net.Tests.csproj
@@ -63,7 +63,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="Quackers.TestLogger" Version="1.0.24" />
   </ItemGroup>

--- a/src/log4net/Appender/EventLogAppender.cs
+++ b/src/log4net/Appender/EventLogAppender.cs
@@ -494,7 +494,7 @@ namespace log4net.Appender
     /// <see cref="Level"/> this is a one way mapping. There is
     /// a loss of information during the conversion.
     /// </remarks>
-    protected virtual EventLogEntryType GetEntryType(Level level)
+    protected internal virtual EventLogEntryType GetEntryType(Level level)
     {
       // see if there is a specified lookup.
       Level2EventLogEntryType entryType = m_levelMapping.Lookup(level) as Level2EventLogEntryType;

--- a/src/log4net/Appender/EventLogAppender.cs
+++ b/src/log4net/Appender/EventLogAppender.cs
@@ -414,7 +414,9 @@ namespace log4net.Appender
       if (loggingEvent.LookupProperty("Category") is object categoryPropertyObj)
       {
         if (categoryPropertyObj is short shortValue)
+        {
           category = shortValue;
+        }
         else
         {
           if (categoryPropertyObj is not string categoryPropertyString)
@@ -423,9 +425,13 @@ namespace log4net.Appender
           {
             // Read the string property into a number
             if (SystemInfo.TryParse(categoryPropertyString, out short shortVal))
+            {
               category = shortVal;
+            }
             else
-              ErrorHandler.Error("Unable to parse event category property [" + categoryPropertyString + "].");
+            {
+              ErrorHandler.Error($"Unable to parse event category property [{categoryPropertyString}].");
+            }
           }
         }
       }
@@ -480,6 +486,7 @@ namespace log4net.Appender
       // Use default behavior
       if (level >= Level.Error)
         return EventLogEntryType.Error;
+
       if (level == Level.Warn)
         return EventLogEntryType.Warning;
 

--- a/src/log4net/Appender/EventLogAppender.cs
+++ b/src/log4net/Appender/EventLogAppender.cs
@@ -411,32 +411,21 @@ namespace log4net.Appender
 
       short category = m_category;
       // Look for the Category property
-      object categoryPropertyObj = loggingEvent.LookupProperty("Category");
-      if (categoryPropertyObj != null)
+      if (loggingEvent.LookupProperty("Category") is object categoryPropertyObj)
       {
-        if (categoryPropertyObj is short)
-        {
-          category = (short)categoryPropertyObj;
-        }
+        if (categoryPropertyObj is short shortValue)
+          category = shortValue;
         else
         {
-          string categoryPropertyString = categoryPropertyObj as string;
-          if (categoryPropertyString == null)
-          {
+          if (categoryPropertyObj is not string categoryPropertyString)
             categoryPropertyString = categoryPropertyObj.ToString();
-          }
-          if (categoryPropertyString != null && categoryPropertyString.Length > 0)
+          if (categoryPropertyString?.Length > 0)
           {
             // Read the string property into a number
-            short shortVal;
-            if (SystemInfo.TryParse(categoryPropertyString, out shortVal))
-            {
+            if (SystemInfo.TryParse(categoryPropertyString, out short shortVal))
               category = shortVal;
-            }
             else
-            {
               ErrorHandler.Error("Unable to parse event category property [" + categoryPropertyString + "].");
-            }
           }
         }
       }
@@ -448,16 +437,12 @@ namespace log4net.Appender
 
         // There is a limit of about 32K characters for an event log message
         if (eventTxt.Length > MAX_EVENTLOG_MESSAGE_SIZE)
-        {
           eventTxt = eventTxt.Substring(0, MAX_EVENTLOG_MESSAGE_SIZE);
-        }
 
         EventLogEntryType entryType = GetEntryType(loggingEvent.Level);
 
         using (SecurityContext.Impersonate(this))
-        {
           EventLog.WriteEntry(m_applicationName, eventTxt, entryType, eventID, category);
-        }
       }
       catch (Exception ex)
       {
@@ -469,15 +454,7 @@ namespace log4net.Appender
     /// This appender requires a <see cref="Layout"/> to be set.
     /// </summary>
     /// <value><c>true</c></value>
-    /// <remarks>
-    /// <para>
-    /// This appender requires a <see cref="Layout"/> to be set.
-    /// </para>
-    /// </remarks>
-    protected override bool RequiresLayout
-    {
-      get { return true; }
-    }
+    protected override bool RequiresLayout => true;
 
     #endregion // Override implementation of AppenderSkeleton
 
@@ -494,25 +471,17 @@ namespace log4net.Appender
     /// <see cref="Level"/> this is a one way mapping. There is
     /// a loss of information during the conversion.
     /// </remarks>
-    protected internal virtual EventLogEntryType GetEntryType(Level level)
+    public virtual EventLogEntryType GetEntryType(Level level)
     {
       // see if there is a specified lookup.
-      Level2EventLogEntryType entryType = m_levelMapping.Lookup(level) as Level2EventLogEntryType;
-      if (entryType != null)
-      {
+      if (m_levelMapping.Lookup(level) is Level2EventLogEntryType entryType)
         return entryType.EventLogEntryType;
-      }
 
       // Use default behavior
-
       if (level >= Level.Error)
-      {
         return EventLogEntryType.Error;
-      }
-      else if (level == Level.Warn)
-      {
+      if (level == Level.Warn)
         return EventLogEntryType.Warning;
-      }
 
       // Default setting
       return EventLogEntryType.Information;

--- a/src/log4net/Appender/FileAppender.cs
+++ b/src/log4net/Appender/FileAppender.cs
@@ -29,6 +29,8 @@ using log4net.Layout;
 using log4net.Core;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace log4net.Appender
 {
   /// <summary>
@@ -110,16 +112,16 @@ namespace log4net.Appender
         }
       }
 
-      private Stream m_realStream = null;
+      private Stream? m_realStream;
       private readonly LockingModelBase m_lockingModel;
-      private int m_lockLevel = 0;
+      private int m_lockLevel;
 
       public LockingStream(LockingModelBase locking)
           : base()
       {
         if (locking == null)
         {
-          throw new ArgumentException("Locking model may not be null", "locking");
+          throw new ArgumentException("Locking model may not be null", nameof(locking));
         }
 
         m_lockingModel = locking;
@@ -135,8 +137,7 @@ namespace log4net.Appender
 
       public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
       {
-        AssertLocked();
-        return m_realStream.ReadAsync(buffer, offset, count, cancellationToken);
+        return AssertLocked().ReadAsync(buffer, offset, count, cancellationToken);
       }
 
       public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -145,32 +146,29 @@ namespace log4net.Appender
         return base.WriteAsync(buffer, offset, count, cancellationToken);
       }
 
-      public override void Flush()
+            public override void Flush()
       {
-        AssertLocked();
-        m_realStream.Flush();
+        AssertLocked().Flush();
       }
 
       public override int Read(byte[] buffer, int offset, int count)
       {
-        return m_realStream.Read(buffer, offset, count);
+        return AssertLocked().Read(buffer, offset, count);
       }
 
       public override int ReadByte()
       {
-        return m_realStream.ReadByte();
+        return AssertLocked().ReadByte();
       }
 
       public override long Seek(long offset, SeekOrigin origin)
       {
-        AssertLocked();
-        return m_realStream.Seek(offset, origin);
+        return AssertLocked().Seek(offset, origin);
       }
 
       public override void SetLength(long value)
       {
-        AssertLocked();
-        m_realStream.SetLength(value);
+        AssertLocked().SetLength(value);
       }
 
       void IDisposable.Dispose()
@@ -180,14 +178,12 @@ namespace log4net.Appender
 
       public override void Write(byte[] buffer, int offset, int count)
       {
-        AssertLocked();
-        m_realStream.Write(buffer, offset, count);
+        AssertLocked().Write(buffer, offset, count);
       }
 
       public override void WriteByte(byte value)
       {
-        AssertLocked();
-        m_realStream.WriteByte(value);
+        AssertLocked().WriteByte(value);
       }
 
       // Properties
@@ -200,8 +196,7 @@ namespace log4net.Appender
       {
         get
         {
-          AssertLocked();
-          return m_realStream.CanSeek;
+          return AssertLocked().CanSeek;
         }
       }
 
@@ -209,8 +204,7 @@ namespace log4net.Appender
       {
         get
         {
-          AssertLocked();
-          return m_realStream.CanWrite;
+          return AssertLocked().CanWrite;
         }
       }
 
@@ -218,8 +212,7 @@ namespace log4net.Appender
       {
         get
         {
-          AssertLocked();
-          return m_realStream.Length;
+          return AssertLocked().Length;
         }
       }
 
@@ -227,26 +220,26 @@ namespace log4net.Appender
       {
         get
         {
-          AssertLocked();
-          return m_realStream.Position;
+          return AssertLocked().Position;
         }
         set
         {
-          AssertLocked();
-          m_realStream.Position = value;
+          AssertLocked().Position = value;
         }
       }
 
-      #endregion Override Implementation of Stream
+            #endregion Override Implementation of Stream
 
-      #region Locking Methods
+            #region Locking Methods
 
-      private void AssertLocked()
+      private Stream AssertLocked()
       {
         if (m_realStream == null)
         {
           throw new LockStateException("The file is not currently locked");
         }
+
+        return m_realStream;
       }
 
       public bool AcquireLock()
@@ -301,8 +294,6 @@ namespace log4net.Appender
     /// </remarks>
     public abstract class LockingModelBase
     {
-      private FileAppender m_appender = null;
-
       /// <summary>
       /// Open the output file
       /// </summary>
@@ -342,23 +333,23 @@ namespace log4net.Appender
       /// <summary>
       /// Acquire the lock on the file
       /// </summary>
-      /// <returns>A stream that is ready to be written to.</returns>
+      /// <returns>A stream that is ready to be written to, or null if there is no active stream because uninitialized or error.</returns>
       /// <remarks>
       /// <para>
-      /// Acquire the lock on the file in preparation for writing to it. 
-      /// Return a stream pointing to the file. <see cref="ReleaseLock"/>
-      /// must be called to release the lock on the output file.
+      /// Acquire the lock on the file in preparation for writing to it.
+      /// Returns a stream pointing to the file. <see cref="ReleaseLock"/>
+      /// must be called to release the lock on the output file when the return
+      /// value is not null.
       /// </para>
       /// </remarks>
-      public abstract Stream AcquireLock();
+      public abstract Stream? AcquireLock();
 
       /// <summary>
-      /// Release the lock on the file
+      /// Releases the lock on the file
       /// </summary>
       /// <remarks>
       /// <para>
-      /// Release the lock on the file. No further writes will be made to the 
-      /// stream until <see cref="AcquireLock"/> is called again.
+      /// No further writes will be made to the stream until <see cref="AcquireLock"/> is called again.
       /// </para>
       /// </remarks>
       public abstract void ReleaseLock();
@@ -382,11 +373,7 @@ namespace log4net.Appender
       /// called.
       /// </para>
       /// </remarks>
-      public FileAppender CurrentAppender
-      {
-        get { return m_appender; }
-        set { m_appender = value; }
-      }
+      public FileAppender? CurrentAppender { get; set; }
 
       /// <summary>
       /// Helper method that creates a FileStream under CurrentAppender's SecurityContext.
@@ -397,7 +384,7 @@ namespace log4net.Appender
       /// </para>
       /// <para>
       /// If the directory portion of the <paramref name="filename"/> does not exist, it is created
-      /// via Directory.CreateDirecctory.
+      /// via Directory.CreateDirectory.
       /// </para>
       /// </remarks>
       /// <param name="filename"></param>
@@ -407,14 +394,14 @@ namespace log4net.Appender
       protected Stream CreateStream(string filename, bool append, FileShare fileShare)
       {
         filename = Environment.ExpandEnvironmentVariables(filename);
-        using (CurrentAppender.SecurityContext.Impersonate(this))
+        using (CurrentAppender?.SecurityContext?.Impersonate(this))
         {
           // Ensure that the directory structure exists
-          string directoryFullName = Path.GetDirectoryName(filename);
+          string? directoryFullName = Path.GetDirectoryName(filename);
 
           // Only create the directory if it does not exist
           // doing this check here resolves some permissions failures
-          if (!Directory.Exists(directoryFullName))
+          if (directoryFullName is not null && !Directory.Exists(directoryFullName))
           {
             Directory.CreateDirectory(directoryFullName);
           }
@@ -435,7 +422,7 @@ namespace log4net.Appender
       /// <param name="stream"></param>
       protected void CloseStream(Stream stream)
       {
-        using (CurrentAppender.SecurityContext.Impersonate(this))
+        using (CurrentAppender?.SecurityContext?.Impersonate(this))
         {
           stream.Dispose();
         }
@@ -453,7 +440,7 @@ namespace log4net.Appender
     /// </remarks>
     public class ExclusiveLock : LockingModelBase
     {
-      private Stream m_stream = null;
+      private Stream? m_stream;
 
       /// <summary>
       /// Open the file specified and prepare for logging.
@@ -477,7 +464,7 @@ namespace log4net.Appender
         }
         catch (Exception e1)
         {
-          CurrentAppender.ErrorHandler.Error("Unable to acquire lock on file " + filename + ". " +
+          CurrentAppender?.ErrorHandler.Error("Unable to acquire lock on file " + filename + ". " +
               e1.Message);
         }
       }
@@ -492,8 +479,11 @@ namespace log4net.Appender
       /// </remarks>
       public override void CloseFile()
       {
-        CloseStream(m_stream);
-        m_stream = null;
+        if (m_stream is not null)
+        {
+          CloseStream(m_stream);
+          m_stream = null;
+        }
       }
 
       /// <summary>
@@ -505,9 +495,9 @@ namespace log4net.Appender
       /// Does nothing. The lock is already taken
       /// </para>
       /// </remarks>
-      public override Stream AcquireLock()
+      public override Stream? AcquireLock()
       {
-        return m_stream;
+          return m_stream;
       }
 
       /// <summary>
@@ -553,9 +543,9 @@ namespace log4net.Appender
     /// </remarks>
     public class MinimalLock : LockingModelBase
     {
-      private string m_filename;
+      private string? m_filename;
       private bool m_append;
-      private Stream m_stream = null;
+      private Stream? m_stream;
 
       /// <summary>
       /// Prepares to open the file when the first message is logged.
@@ -601,19 +591,26 @@ namespace log4net.Appender
       /// must be called to release the lock on the output file.
       /// </para>
       /// </remarks>
-      public override Stream AcquireLock()
+      public override Stream? AcquireLock()
       {
-        if (m_stream == null)
+        if (m_stream is null)
         {
-          try
+          if (m_filename is not null)
           {
-            m_stream = CreateStream(m_filename, m_append, FileShare.Read);
-            m_append = true;
+            try
+            {
+              m_stream = CreateStream(m_filename, m_append, FileShare.Read);
+              m_append = true;
+            }
+            catch (Exception e1)
+            {
+              CurrentAppender?.ErrorHandler.Error("Unable to acquire lock on file " + m_filename + ". " +
+                  e1.Message);
+            }
           }
-          catch (Exception e1)
+          else
           {
-            CurrentAppender.ErrorHandler.Error("Unable to acquire lock on file " + m_filename + ". " +
-                e1.Message);
+            CurrentAppender?.ErrorHandler.Error($"Unable to acquire lock because {nameof(OpenFile)} has not been called");
           }
         }
 
@@ -631,8 +628,11 @@ namespace log4net.Appender
       /// </remarks>
       public override void ReleaseLock()
       {
-        CloseStream(m_stream);
-        m_stream = null;
+        if (m_stream is not null)
+        {
+          CloseStream(m_stream);
+          m_stream = null;
+        }
       }
 
       /// <summary>
@@ -659,9 +659,9 @@ namespace log4net.Appender
     /// <author>Steve Wranovsky</author>
     public class InterProcessLock : LockingModelBase
     {
-      private Mutex m_mutex = null;
-      private Stream m_stream = null;
-      private int m_recursiveWatch = 0;
+      private Mutex? m_mutex;
+      private Stream? m_stream;
+      private int m_recursiveWatch;
 
       /// <summary>
       /// Open the file specified and prepare for logging.
@@ -686,7 +686,7 @@ namespace log4net.Appender
         }
         catch (Exception e1)
         {
-          CurrentAppender.ErrorHandler.Error("Unable to acquire lock on file " + filename + ". " +
+          CurrentAppender?.ErrorHandler.Error("Unable to acquire lock on file " + filename + ". " +
               e1.Message);
         }
       }
@@ -703,8 +703,11 @@ namespace log4net.Appender
       {
         try
         {
-          CloseStream(m_stream);
-          m_stream = null;
+          if (m_stream is not null)
+          {
+            CloseStream(m_stream);
+            m_stream = null;
+          }
         }
         finally
         {
@@ -721,7 +724,7 @@ namespace log4net.Appender
       /// Does nothing. The lock is already taken
       /// </para>
       /// </remarks>
-      public override Stream AcquireLock()
+      public override Stream? AcquireLock()
       {
         if (m_mutex != null)
         {
@@ -746,7 +749,7 @@ namespace log4net.Appender
         }
         else
         {
-          CurrentAppender.ErrorHandler.Error(
+          CurrentAppender?.ErrorHandler.Error(
               "Programming error, no mutex available to acquire lock! From here on things will be dangerous!");
         }
 
@@ -768,7 +771,7 @@ namespace log4net.Appender
         }
         else
         {
-          CurrentAppender.ErrorHandler.Error("Programming error, no mutex available to release the lock!");
+          CurrentAppender?.ErrorHandler.Error("Programming error, no mutex available to release the lock!");
         }
       }
 
@@ -779,16 +782,26 @@ namespace log4net.Appender
       {
         if (m_mutex == null)
         {
-          string mutexFriendlyFilename = CurrentAppender.File
-              .Replace("\\", "_")
-              .Replace(":", "_")
-              .Replace("/", "_");
+          if (CurrentAppender is not null)
+          {
+            if (CurrentAppender.File is not null)
+            {
+              string mutexFriendlyFilename = CurrentAppender.File
+                  .Replace("\\", "_")
+                  .Replace(":", "_")
+                  .Replace("/", "_");
 
-          m_mutex = new Mutex(false, mutexFriendlyFilename);
+              m_mutex = new Mutex(false, mutexFriendlyFilename);
+            }
+            else
+            {
+              CurrentAppender.ErrorHandler.Error($"Current appender has no file name, {nameof(OpenFile)} not called or it encountered an error");
+            }
+          }
         }
         else
         {
-          CurrentAppender.ErrorHandler.Error("Programming error, mutex already initialized!");
+          CurrentAppender?.ErrorHandler.Error("Programming error, mutex already initialized!");
         }
       }
 
@@ -804,7 +817,7 @@ namespace log4net.Appender
         }
         else
         {
-          CurrentAppender.ErrorHandler.Error("Programming error, mutex not initialized!");
+          CurrentAppender?.ErrorHandler.Error("Programming error, mutex not initialized!");
         }
       }
     }
@@ -820,7 +833,7 @@ namespace log4net.Appender
     /// </remarks>
     public class NoLock : LockingModelBase
     {
-      private Stream m_stream = null;
+      private Stream? m_stream;
 
       /// <summary>
       /// Open the file specified and prepare for logging.
@@ -845,7 +858,7 @@ namespace log4net.Appender
         }
         catch (Exception e1)
         {
-          CurrentAppender.ErrorHandler.Error(
+          CurrentAppender?.ErrorHandler.Error(
               $"Unable to acquire lock on file {filename}. {e1.Message}"
           );
         }
@@ -861,8 +874,11 @@ namespace log4net.Appender
       /// </remarks>
       public override void CloseFile()
       {
-        CloseStream(m_stream);
-        m_stream = null;
+        if (m_stream is not null)
+        {
+          CloseStream(m_stream);
+          m_stream = null;
+        }
       }
 
       /// <summary>
@@ -874,7 +890,7 @@ namespace log4net.Appender
       /// Does nothing. The lock is already taken
       /// </para>
       /// </remarks>
-      public override Stream AcquireLock()
+      public override Stream? AcquireLock()
       {
         return m_stream;
       }
@@ -992,7 +1008,7 @@ namespace log4net.Appender
     /// the application base directory.
     /// </para>
     /// </remarks>
-    public virtual string File
+    public virtual string? File
     {
       get { return m_fileName; }
       set { m_fileName = value; }
@@ -1012,11 +1028,7 @@ namespace log4net.Appender
     /// </para>
     /// The default value is true.
     /// </remarks>
-    public bool AppendToFile
-    {
-      get { return m_appendToFile; }
-      set { m_appendToFile = value; }
-    }
+    public bool AppendToFile { get; set; } = true;
 
     /// <summary>
     /// Gets or sets <see cref="Encoding"/> used to write to the file.
@@ -1030,11 +1042,7 @@ namespace log4net.Appender
     /// which is the encoding for the system's current ANSI code page.
     /// </para>
     /// </remarks>
-    public Encoding Encoding
-    {
-      get { return m_encoding; }
-      set { m_encoding = value; }
-    }
+    public Encoding Encoding { get; set; } = Encoding.GetEncoding(0);
 
     /// <summary>
     /// Gets or sets the <see cref="SecurityContext"/> used to write to the file.
@@ -1050,11 +1058,7 @@ namespace log4net.Appender
     /// of the current thread.
     /// </para>
     /// </remarks>
-    public SecurityContext SecurityContext
-    {
-      get { return m_securityContext; }
-      set { m_securityContext = value; }
-    }
+    public SecurityContext? SecurityContext { get; set; }
 
     /// <summary>
     /// Gets or sets the <see cref="FileAppender.LockingModel"/> used to handle locking of the file.
@@ -1076,11 +1080,7 @@ namespace log4net.Appender
     /// The default locking model is the <see cref="FileAppender.ExclusiveLock"/>.
     /// </para>
     /// </remarks>
-    public FileAppender.LockingModelBase LockingModel
-    {
-      get { return m_lockingModel; }
-      set { m_lockingModel = value; }
-    }
+    public LockingModelBase LockingModel { get; set; } = (LockingModelBase)Activator.CreateInstance(defaultLockingModelType);
 
     #endregion Public Instance Properties
 
@@ -1109,18 +1109,10 @@ namespace log4net.Appender
     {
       base.ActivateOptions();
 
-      if (m_securityContext == null)
-      {
-        m_securityContext = SecurityContextProvider.DefaultProvider.CreateSecurityContext(this);
-      }
+      SecurityContext ??= SecurityContextProvider.DefaultProvider.CreateSecurityContext(this);
 
-      if (m_lockingModel == null)
-      {
-        m_lockingModel = (LockingModelBase)Activator.CreateInstance(defaultLockingModelType);
-      }
-
-      m_lockingModel.CurrentAppender = this;
-      m_lockingModel.ActivateOptions();
+      LockingModel.CurrentAppender = this;
+      LockingModel.ActivateOptions();
 
       if (m_fileName != null)
       {
@@ -1129,7 +1121,7 @@ namespace log4net.Appender
           m_fileName = ConvertToFullPath(m_fileName.Trim());
         }
 
-        SafeOpenFile(m_fileName, m_appendToFile);
+        SafeOpenFile(m_fileName, AppendToFile);
       }
       else
       {
@@ -1162,7 +1154,7 @@ namespace log4net.Appender
     protected override void OnClose()
     {
       base.OnClose();
-      m_lockingModel?.OnClose();
+      LockingModel.OnClose();
     }
 
     /// <summary>
@@ -1176,7 +1168,10 @@ namespace log4net.Appender
     /// </remarks>
     protected override void PrepareWriter()
     {
-      SafeOpenFile(m_fileName, m_appendToFile);
+      if (m_fileName is not null)
+      {
+        SafeOpenFile(m_fileName, AppendToFile);
+      }
     }
 
     /// <summary>
@@ -1195,7 +1190,7 @@ namespace log4net.Appender
     /// </remarks>
     protected override void Append(LoggingEvent loggingEvent)
     {
-      if (m_stream.AcquireLock())
+      if (m_stream is not null && m_stream.AcquireLock())
       {
         try
         {
@@ -1221,7 +1216,7 @@ namespace log4net.Appender
     /// </remarks>
     protected override void Append(LoggingEvent[] loggingEvents)
     {
-      if (m_stream.AcquireLock())
+      if (m_stream is not null && m_stream.AcquireLock())
       {
         try
         {
@@ -1375,8 +1370,8 @@ namespace log4net.Appender
       if (LogLog.IsErrorEnabled)
       {
         // Internal check that the fileName passed in is a rooted path
-        bool isPathRooted = false;
-        using (SecurityContext.Impersonate(this))
+        bool isPathRooted;
+        using (SecurityContext?.Impersonate(this))
         {
           isPathRooted = Path.IsPathRooted(fileName);
         }
@@ -1396,10 +1391,10 @@ namespace log4net.Appender
 
         // Save these for later, allowing retries if file open fails
         m_fileName = fileName;
-        m_appendToFile = append;
+        AppendToFile = append;
 
         LockingModel.CurrentAppender = this;
-        LockingModel.OpenFile(fileName, append, m_encoding);
+        LockingModel.OpenFile(fileName, append, Encoding);
         m_stream = new LockingStream(LockingModel);
 
         if (m_stream != null)
@@ -1438,7 +1433,7 @@ namespace log4net.Appender
     protected virtual void SetQWForFiles(Stream fileStream)
     {
 #pragma warning disable CA2000 // Dispose objects before losing scope
-      StreamWriter writer = new StreamWriter(fileStream, m_encoding);
+      StreamWriter writer = new StreamWriter(fileStream, Encoding);
 #pragma warning restore CA2000 // Dispose objects before losing scope
       SetQWForFiles(writer);
     }
@@ -1485,35 +1480,14 @@ namespace log4net.Appender
     #region Private Instance Fields
 
     /// <summary>
-    /// Flag to indicate if we should append to the file
-    /// or overwrite the file. The default is to append.
-    /// </summary>
-    private bool m_appendToFile = true;
-
-    /// <summary>
     /// The name of the log file.
     /// </summary>
-    private string m_fileName = null;
-
-    /// <summary>
-    /// The encoding to use for the file stream.
-    /// </summary>
-    private Encoding m_encoding = Encoding.GetEncoding(0);
-
-    /// <summary>
-    /// The security context to use for privileged calls
-    /// </summary>
-    private SecurityContext m_securityContext;
+    private string? m_fileName;
 
     /// <summary>
     /// The stream to log to. Has added locking semantics
     /// </summary>
-    private FileAppender.LockingStream m_stream = null;
-
-    /// <summary>
-    /// The locking model to use
-    /// </summary>
-    private FileAppender.LockingModelBase m_lockingModel;
+    private LockingStream? m_stream;
 
     #endregion Private Instance Fields
 

--- a/src/log4net/Appender/FileAppender.cs
+++ b/src/log4net/Appender/FileAppender.cs
@@ -146,7 +146,7 @@ namespace log4net.Appender
         return base.WriteAsync(buffer, offset, count, cancellationToken);
       }
 
-            public override void Flush()
+      public override void Flush()
       {
         AssertLocked().Flush();
       }
@@ -228,9 +228,9 @@ namespace log4net.Appender
         }
       }
 
-            #endregion Override Implementation of Stream
+      #endregion Override Implementation of Stream
 
-            #region Locking Methods
+      #region Locking Methods
 
       private Stream AssertLocked()
       {

--- a/src/log4net/Appender/RollingFileAppender.DateTime.cs
+++ b/src/log4net/Appender/RollingFileAppender.DateTime.cs
@@ -1,0 +1,84 @@
+#region Apache License
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more 
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership. 
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with 
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+
+#nullable enable
+
+namespace log4net.Appender
+{
+  public partial class RollingFileAppender
+  {
+    /// <summary>
+    /// This interface is used to supply Date/Time information to the <see cref="RollingFileAppender"/>.
+    /// </summary>
+    /// <remarks>
+    /// This interface is used to supply Date/Time information to the <see cref="RollingFileAppender"/>.
+    /// Used primarily to allow test classes to plug themselves in so they can
+    /// supply test date/times.
+    /// </remarks>
+    public interface IDateTime
+    {
+      /// <summary>
+      /// Gets the <i>current</i> time.
+      /// </summary>
+      /// <value>The <i>current</i> time.</value>
+      /// <remarks>
+      /// <para>
+      /// Gets the <i>current</i> time.
+      /// </para>
+      /// </remarks>
+      DateTime Now { get; }
+    }
+
+    /// <summary>
+    /// Default implementation of <see cref="IDateTime"/> that returns the current time.
+    /// </summary>
+    private sealed class LocalDateTime : IDateTime
+    {
+      /// <summary>
+      /// Gets the <b>current</b> time.
+      /// </summary>
+      /// <value>The <b>current</b> time.</value>
+      /// <remarks>
+      /// <para>
+      /// Gets the <b>current</b> time.
+      /// </para>
+      /// </remarks>
+      public DateTime Now => DateTime.Now;
+    }
+
+    /// <summary>
+    /// Implementation of <see cref="IDateTime"/> that returns the current time as the coordinated universal time (UTC).
+    /// </summary>
+    private sealed class UniversalDateTime : IDateTime
+    {
+      /// <summary>
+      /// Gets the <b>current</b> time.
+      /// </summary>
+      /// <value>The <b>current</b> time.</value>
+      /// <remarks>
+      /// <para>
+      /// Gets the <b>current</b> time.
+      /// </para>
+      /// </remarks>
+      public DateTime Now => DateTime.UtcNow;
+    }
+  }
+}

--- a/src/log4net/Appender/RollingFileAppender.cs
+++ b/src/log4net/Appender/RollingFileAppender.cs
@@ -21,15 +21,12 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Runtime.CompilerServices;
 
 using log4net.Util;
 using log4net.Core;
 using System.Threading;
 
 #nullable enable
-
-[assembly: InternalsVisibleTo("log4net.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100297dcac908e28689360399027b0ea4cd852fbb74e1ed95e695a5ba55cbd1d075ec20cdb5fa6fc593d3d571527b20558d6f39e1f4d5cfe0798428c589c311965244b209c38a02aaa8c9da3b72405b6fedeeb4292c3457e9769b74e645c19cb06c2be75fb2d12281a585fbeabf7bd195d6961ba113286fc3e286d7bbd69024ceda")]
 
 namespace log4net.Appender
 {
@@ -1333,7 +1330,7 @@ namespace log4net.Appender
 
       if (File is not null)
       {
-          RollOverRenameFiles(File);
+        RollOverRenameFiles(File);
       }
 
       if (!StaticLogFileName && CountDirection >= 0)

--- a/src/log4net/AssemblyInfo.cs
+++ b/src/log4net/AssemblyInfo.cs
@@ -64,5 +64,3 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyProduct("log4net")]
 [assembly: AssemblyDefaultAlias("log4net")]
 [assembly: AssemblyCulture("")]
-
-[assembly: InternalsVisibleTo("log4net.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100297dcac908e28689360399027b0ea4cd852fbb74e1ed95e695a5ba55cbd1d075ec20cdb5fa6fc593d3d571527b20558d6f39e1f4d5cfe0798428c589c311965244b209c38a02aaa8c9da3b72405b6fedeeb4292c3457e9769b74e645c19cb06c2be75fb2d12281a585fbeabf7bd195d6961ba113286fc3e286d7bbd69024ceda")]

--- a/src/log4net/AssemblyInfo.cs
+++ b/src/log4net/AssemblyInfo.cs
@@ -18,6 +18,7 @@
 #endregion
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 //
 // log4net makes use of static methods which cannot be made com visible
@@ -63,3 +64,5 @@ using System.Reflection;
 [assembly: AssemblyProduct("log4net")]
 [assembly: AssemblyDefaultAlias("log4net")]
 [assembly: AssemblyCulture("")]
+
+[assembly: InternalsVisibleTo("log4net.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100297dcac908e28689360399027b0ea4cd852fbb74e1ed95e695a5ba55cbd1d075ec20cdb5fa6fc593d3d571527b20558d6f39e1f4d5cfe0798428c589c311965244b209c38a02aaa8c9da3b72405b6fedeeb4292c3457e9769b74e645c19cb06c2be75fb2d12281a585fbeabf7bd195d6961ba113286fc3e286d7bbd69024ceda")]

--- a/src/log4net/Core/LoggingEvent.cs
+++ b/src/log4net/Core/LoggingEvent.cs
@@ -27,6 +27,7 @@ using System.Security;
 using System.Security.Principal;
 using log4net.Util;
 using log4net.Repository;
+using System.ComponentModel;
 
 namespace log4net.Core
 {
@@ -110,13 +111,10 @@ namespace log4net.Core
     {
       get
       {
-        if (TimeStamp != default(DateTime) &&
-            _timeStampUtc == default(DateTime))
-        {
+        if (TimeStamp != default && _timeStampUtc == default)
           // TimeStamp field has been set explicitly but TimeStampUtc hasn't
           // => use TimeStamp
           return TimeStamp.ToUniversalTime();
-        }
 
         return _timeStampUtc;
       }
@@ -1479,7 +1477,12 @@ namespace log4net.Core
     /// <summary>
     /// The internal logging event data.
     /// </summary>
-    internal LoggingEventData m_data;
+    private LoggingEventData m_data;
+
+    /// <summary>
+    /// Location information for the caller.
+    /// </summary>
+    public LocationInfo LocationInfo => m_data.LocationInfo;
 
     /// <summary>
     /// The internal logging event data.

--- a/src/log4net/Core/LoggingEvent.cs
+++ b/src/log4net/Core/LoggingEvent.cs
@@ -1479,7 +1479,7 @@ namespace log4net.Core
     /// <summary>
     /// The internal logging event data.
     /// </summary>
-    private LoggingEventData m_data;
+    internal LoggingEventData m_data;
 
     /// <summary>
     /// The internal logging event data.

--- a/src/log4net/Layout/Pattern/PatternLayoutConverter.cs
+++ b/src/log4net/Layout/Pattern/PatternLayoutConverter.cs
@@ -96,10 +96,10 @@ namespace log4net.Layout.Pattern
     /// <param name="state">The state object on which the pattern converter should be executed.</param>
     public override void Convert(TextWriter writer, object state)
     {
-      if (state is LoggingEvent loggingEvent)
-        Convert(writer, loggingEvent);
-      else
-        throw new ArgumentException("state must be of type [" + typeof(LoggingEvent).FullName + "]", "state");
+      if (state is not LoggingEvent loggingEvent)
+        throw new ArgumentException($"state must be of type [{typeof(LoggingEvent).FullName}]", "state");
+
+      Convert(writer, loggingEvent);
     }
 
     #endregion Protected Methods

--- a/src/log4net/Layout/Pattern/PatternLayoutConverter.cs
+++ b/src/log4net/Layout/Pattern/PatternLayoutConverter.cs
@@ -18,13 +18,10 @@
 #endregion
 
 using System;
-using System.Text;
 using System.IO;
-using System.Collections;
 
 using log4net.Core;
 using log4net.Util;
-using log4net.Repository;
 
 namespace log4net.Layout.Pattern
 {
@@ -97,7 +94,7 @@ namespace log4net.Layout.Pattern
     /// </summary>
     /// <param name="writer"><see cref="TextWriter" /> that will receive the formatted result.</param>
     /// <param name="state">The state object on which the pattern converter should be executed.</param>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       LoggingEvent loggingEvent = state as LoggingEvent;
       if (loggingEvent != null)

--- a/src/log4net/Layout/Pattern/PatternLayoutConverter.cs
+++ b/src/log4net/Layout/Pattern/PatternLayoutConverter.cs
@@ -94,17 +94,12 @@ namespace log4net.Layout.Pattern
     /// </summary>
     /// <param name="writer"><see cref="TextWriter" /> that will receive the formatted result.</param>
     /// <param name="state">The state object on which the pattern converter should be executed.</param>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
-      LoggingEvent loggingEvent = state as LoggingEvent;
-      if (loggingEvent != null)
-      {
+      if (state is LoggingEvent loggingEvent)
         Convert(writer, loggingEvent);
-      }
       else
-      {
         throw new ArgumentException("state must be of type [" + typeof(LoggingEvent).FullName + "]", "state");
-      }
     }
 
     #endregion Protected Methods

--- a/src/log4net/Layout/Pattern/PropertyPatternConverter.cs
+++ b/src/log4net/Layout/Pattern/PropertyPatternConverter.cs
@@ -17,13 +17,9 @@
 //
 #endregion
 
-using System;
-using System.Text;
 using System.IO;
-using System.Collections;
 
 using log4net.Core;
-using log4net.Repository;
 
 namespace log4net.Layout.Pattern
 {

--- a/src/log4net/Util/PatternConverter.cs
+++ b/src/log4net/Util/PatternConverter.cs
@@ -21,7 +21,6 @@ using System.Text;
 using System.IO;
 using System.Collections;
 
-using log4net.Util;
 using log4net.Repository;
 
 namespace log4net.Util
@@ -129,7 +128,7 @@ namespace log4net.Util
     /// convert conversion specifiers in the appropriate way.
     /// </para>
     /// </remarks>
-    protected abstract void Convert(TextWriter writer, object state);
+    protected internal abstract void Convert(TextWriter writer, object state);
 
     #endregion Protected Abstract Methods
 

--- a/src/log4net/Util/PatternConverter.cs
+++ b/src/log4net/Util/PatternConverter.cs
@@ -128,7 +128,7 @@ namespace log4net.Util
     /// convert conversion specifiers in the appropriate way.
     /// </para>
     /// </remarks>
-    protected internal abstract void Convert(TextWriter writer, object state);
+    public abstract void Convert(TextWriter writer, object state);
 
     #endregion Protected Abstract Methods
 

--- a/src/log4net/Util/PatternStringConverters/AppDomainPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/AppDomainPatternConverter.cs
@@ -17,11 +17,7 @@
 //
 #endregion
 
-using System;
-using System.Text;
 using System.IO;
-
-using log4net.Util;
 
 namespace log4net.Util.PatternStringConverters
 {
@@ -46,7 +42,7 @@ namespace log4net.Util.PatternStringConverters
     /// Writes name of the current AppDomain to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       writer.Write(SystemInfo.ApplicationFriendlyName);
     }

--- a/src/log4net/Util/PatternStringConverters/AppDomainPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/AppDomainPatternConverter.cs
@@ -42,9 +42,7 @@ namespace log4net.Util.PatternStringConverters
     /// Writes name of the current AppDomain to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
-    {
-      writer.Write(SystemInfo.ApplicationFriendlyName);
-    }
+    public override void Convert(TextWriter writer, object state)
+      => writer.Write(SystemInfo.ApplicationFriendlyName);
   }
 }

--- a/src/log4net/Util/PatternStringConverters/AppSettingPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/AppSettingPatternConverter.cs
@@ -86,7 +86,7 @@ namespace log4net.Util.PatternStringConverters
     /// then all the properties are written as key value pairs.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
 
       if (Option != null)

--- a/src/log4net/Util/PatternStringConverters/AppSettingPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/AppSettingPatternConverter.cs
@@ -86,19 +86,14 @@ namespace log4net.Util.PatternStringConverters
     /// then all the properties are written as key value pairs.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
-
-      if (Option != null)
-      {
+      if (Option is not null)
         // Write the value for the specified key
         WriteObject(writer, null, ConfigurationManager.AppSettings[Option]);
-      }
       else
-      {
         // Write all the key value pairs
         WriteDictionary(writer, null, AppSettingsDictionary);
-      }
     }
   }
 }

--- a/src/log4net/Util/PatternStringConverters/DatePatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/DatePatternConverter.cs
@@ -161,7 +161,7 @@ namespace log4net.Util.PatternStringConverters
     /// The date and time passed is in the local time zone.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/DatePatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/DatePatternConverter.cs
@@ -161,7 +161,7 @@ namespace log4net.Util.PatternStringConverters
     /// The date and time passed is in the local time zone.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/EnvironmentFolderPathPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/EnvironmentFolderPathPatternConverter.cs
@@ -49,7 +49,7 @@ namespace log4net.Util.PatternStringConverters
     /// property.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/EnvironmentFolderPathPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/EnvironmentFolderPathPatternConverter.cs
@@ -49,20 +49,18 @@ namespace log4net.Util.PatternStringConverters
     /// property.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {
-        if (Option != null && Option.Length > 0)
+        if (Option?.Length > 0)
         {
           Environment.SpecialFolder specialFolder =
               (Environment.SpecialFolder)Enum.Parse(typeof(Environment.SpecialFolder), Option, true);
 
           string envFolderPathValue = Environment.GetFolderPath(specialFolder);
-          if (envFolderPathValue != null && envFolderPathValue.Length > 0)
-          {
+          if (envFolderPathValue?.Length > 0)
             writer.Write(envFolderPathValue);
-          }
         }
       }
       catch (System.Security.SecurityException secEx)

--- a/src/log4net/Util/PatternStringConverters/EnvironmentPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/EnvironmentPatternConverter.cs
@@ -48,7 +48,7 @@ namespace log4net.Util.PatternStringConverters
     /// property.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/EnvironmentPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/EnvironmentPatternConverter.cs
@@ -33,7 +33,7 @@ namespace log4net.Util.PatternStringConverters
   /// </para>
   /// </remarks>
   /// <author>Nicko Cadell</author>
-  internal sealed class EnvironmentPatternConverter : PatternConverter
+  public sealed class EnvironmentPatternConverter : PatternConverter
   {
     /// <summary>
     /// Write an environment variable to the output
@@ -48,31 +48,23 @@ namespace log4net.Util.PatternStringConverters
     /// property.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {
-        if (this.Option != null && this.Option.Length > 0)
+        if (Option?.Length > 0)
         {
           // Lookup the environment variable
-          string envValue = Environment.GetEnvironmentVariable(this.Option);
+          string envValue = Environment.GetEnvironmentVariable(Option);
 
           // If we didn't see it for the process, try a user level variable.
-          if (envValue == null)
-          {
-            envValue = Environment.GetEnvironmentVariable(this.Option, EnvironmentVariableTarget.User);
-          }
+          envValue ??= Environment.GetEnvironmentVariable(Option, EnvironmentVariableTarget.User);
 
           // If we still didn't find it, try a system level one.
-          if (envValue == null)
-          {
-            envValue = Environment.GetEnvironmentVariable(this.Option, EnvironmentVariableTarget.Machine);
-          }
+          envValue ??= Environment.GetEnvironmentVariable(Option, EnvironmentVariableTarget.Machine);
 
-          if (envValue != null && envValue.Length > 0)
-          {
+          if (envValue?.Length > 0)
             writer.Write(envValue);
-          }
         }
       }
       catch (System.Security.SecurityException secEx)

--- a/src/log4net/Util/PatternStringConverters/IdentityPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/IdentityPatternConverter.cs
@@ -43,7 +43,7 @@ namespace log4net.Util.PatternStringConverters
     /// Writes the current thread identity to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/IdentityPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/IdentityPatternConverter.cs
@@ -18,10 +18,7 @@
 #endregion
 
 using System;
-using System.Text;
 using System.IO;
-
-using log4net.Util;
 
 namespace log4net.Util.PatternStringConverters
 {
@@ -46,7 +43,7 @@ namespace log4net.Util.PatternStringConverters
     /// Writes the current thread identity to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/LiteralPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/LiteralPatternConverter.cs
@@ -18,10 +18,7 @@
 #endregion
 
 using System;
-using System.Text;
 using System.IO;
-
-using log4net.Util;
 
 namespace log4net.Util.PatternStringConverters
 {
@@ -99,7 +96,7 @@ namespace log4net.Util.PatternStringConverters
     /// This method is not used.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       throw new InvalidOperationException("Should never get here because of the overridden Format method");
     }

--- a/src/log4net/Util/PatternStringConverters/LiteralPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/LiteralPatternConverter.cs
@@ -53,12 +53,10 @@ namespace log4net.Util.PatternStringConverters
     /// </remarks>
     public override PatternConverter SetNext(PatternConverter pc)
     {
-      LiteralPatternConverter literalPc = pc as LiteralPatternConverter;
-      if (literalPc != null)
+      if (pc is LiteralPatternConverter literalPc)
       {
         // Combine the two adjacent literals together
         Option = Option + literalPc.Option;
-
         // We are the next converter now
         return this;
       }
@@ -82,9 +80,7 @@ namespace log4net.Util.PatternStringConverters
     /// </para>
     /// </remarks>
     public override void Format(TextWriter writer, object state)
-    {
-      writer.Write(Option);
-    }
+      => writer.Write(Option);
 
     /// <summary>
     /// Convert this pattern into the rendered message
@@ -96,9 +92,7 @@ namespace log4net.Util.PatternStringConverters
     /// This method is not used.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
-    {
-      throw new InvalidOperationException("Should never get here because of the overridden Format method");
-    }
+    public override void Convert(TextWriter writer, object state)
+      => throw new InvalidOperationException("Should never get here because of the overridden Format method");
   }
 }

--- a/src/log4net/Util/PatternStringConverters/ProcessIdPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/ProcessIdPatternConverter.cs
@@ -44,7 +44,7 @@ namespace log4net.Util.PatternStringConverters
     /// </para>
     /// </remarks>
     [System.Security.SecuritySafeCritical]
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/ProcessIdPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/ProcessIdPatternConverter.cs
@@ -44,7 +44,7 @@ namespace log4net.Util.PatternStringConverters
     /// </para>
     /// </remarks>
     [System.Security.SecuritySafeCritical]
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/PropertyPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/PropertyPatternConverter.cs
@@ -57,7 +57,7 @@ namespace log4net.Util.PatternStringConverters
     /// then all the properties are written as key value pairs.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       CompositeProperties compositeProperties = new CompositeProperties();
 

--- a/src/log4net/Util/PatternStringConverters/PropertyPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/PropertyPatternConverter.cs
@@ -57,35 +57,24 @@ namespace log4net.Util.PatternStringConverters
     /// then all the properties are written as key value pairs.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       CompositeProperties compositeProperties = new CompositeProperties();
 
-      PropertiesDictionary logicalThreadProperties = LogicalThreadContext.Properties.GetProperties(false);
-      if (logicalThreadProperties != null)
-      {
+      if (LogicalThreadContext.Properties.GetProperties(false) is PropertiesDictionary logicalThreadProperties)
         compositeProperties.Add(logicalThreadProperties);
-      }
 
-      PropertiesDictionary threadProperties = ThreadContext.Properties.GetProperties(false);
-      if (threadProperties != null)
-      {
+      if (ThreadContext.Properties.GetProperties(false) is PropertiesDictionary threadProperties)
         compositeProperties.Add(threadProperties);
-      }
 
-      // TODO: Add Repository Properties
       compositeProperties.Add(GlobalContext.Properties.GetReadOnlyProperties());
 
-      if (Option != null)
-      {
+      if (Option is not null)
         // Write the value for the specified key
         WriteObject(writer, null, compositeProperties[Option]);
-      }
       else
-      {
         // Write all the key value pairs
         WriteDictionary(writer, null, compositeProperties.Flatten());
-      }
     }
   }
 }

--- a/src/log4net/Util/PatternStringConverters/PropertyPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/PropertyPatternConverter.cs
@@ -59,7 +59,7 @@ namespace log4net.Util.PatternStringConverters
     /// </remarks>
     public override void Convert(TextWriter writer, object state)
     {
-      CompositeProperties compositeProperties = new CompositeProperties();
+      CompositeProperties compositeProperties = new();
 
       if (LogicalThreadContext.Properties.GetProperties(false) is PropertiesDictionary logicalThreadProperties)
         compositeProperties.Add(logicalThreadProperties);
@@ -70,11 +70,15 @@ namespace log4net.Util.PatternStringConverters
       compositeProperties.Add(GlobalContext.Properties.GetReadOnlyProperties());
 
       if (Option is not null)
+      {
         // Write the value for the specified key
         WriteObject(writer, null, compositeProperties[Option]);
+      }
       else
+      {
         // Write all the key value pairs
         WriteDictionary(writer, null, compositeProperties.Flatten());
+      }
     }
   }
 }

--- a/src/log4net/Util/PatternStringConverters/RandomStringPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/RandomStringPatternConverter.cs
@@ -18,11 +18,8 @@
 #endregion
 
 using System;
-using System.Text;
 using System.IO;
 
-using log4net.Util;
-using log4net.DateFormatter;
 using log4net.Core;
 
 namespace log4net.Util.PatternStringConverters
@@ -104,7 +101,7 @@ namespace log4net.Util.PatternStringConverters
     /// Write a randoim string to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/RandomStringPatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/RandomStringPatternConverter.cs
@@ -34,15 +34,14 @@ namespace log4net.Util.PatternStringConverters
   /// to the string value of the length required.
   /// </para>
   /// <para>
-  /// The random characters in the string are limited to uppercase letters
-  /// and numbers only.
+  /// The random characters in the string are limited to uppercase letters and numbers only.
   /// </para>
   /// <para>
   /// The random number generator used by this class is not cryptographically secure.
   /// </para>
   /// </remarks>
   /// <author>Nicko Cadell</author>
-  internal sealed class RandomStringPatternConverter : PatternConverter, IOptionHandler
+  public sealed class RandomStringPatternConverter : PatternConverter, IOptionHandler
   {
     /// <summary>
     /// Shared random number generator
@@ -101,7 +100,7 @@ namespace log4net.Util.PatternStringConverters
     /// Write a randoim string to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/UserNamePatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/UserNamePatternConverter.cs
@@ -43,16 +43,12 @@ namespace log4net.Util.PatternStringConverters
     /// Write the current threads username to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {
-        System.Security.Principal.WindowsIdentity windowsIdentity = null;
-        windowsIdentity = System.Security.Principal.WindowsIdentity.GetCurrent();
-        if (windowsIdentity != null && windowsIdentity.Name != null)
-        {
-          writer.Write(windowsIdentity.Name);
-        }
+        if (System.Security.Principal.WindowsIdentity.GetCurrent()?.Name is string name)
+          writer.Write(name);
       }
       catch (System.Security.SecurityException)
       {

--- a/src/log4net/Util/PatternStringConverters/UserNamePatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/UserNamePatternConverter.cs
@@ -43,7 +43,7 @@ namespace log4net.Util.PatternStringConverters
     /// Write the current threads username to the output <paramref name="writer"/>.
     /// </para>
     /// </remarks>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/UtcDatePatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/UtcDatePatternConverter.cs
@@ -55,7 +55,7 @@ namespace log4net.Util.PatternStringConverters
     /// </para>
     /// </remarks>
     /// <seealso cref="DatePatternConverter"/>
-    protected internal override void Convert(TextWriter writer, object state)
+    public override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/Util/PatternStringConverters/UtcDatePatternConverter.cs
+++ b/src/log4net/Util/PatternStringConverters/UtcDatePatternConverter.cs
@@ -18,11 +18,8 @@
 #endregion
 
 using System;
-using System.Text;
 using System.IO;
 
-using log4net.Core;
-using log4net.Util;
 using log4net.DateFormatter;
 
 namespace log4net.Util.PatternStringConverters
@@ -58,7 +55,7 @@ namespace log4net.Util.PatternStringConverters
     /// </para>
     /// </remarks>
     /// <seealso cref="DatePatternConverter"/>
-    protected override void Convert(TextWriter writer, object state)
+    protected internal override void Convert(TextWriter writer, object state)
     {
       try
       {

--- a/src/log4net/log4net.csproj
+++ b/src/log4net/log4net.csproj
@@ -22,7 +22,6 @@
     <Platforms>AnyCPU</Platforms>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
-    <LangVersion>latest</LangVersion>
     <RootNamespace>log4net</RootNamespace>
     <AssemblyName>log4net</AssemblyName>
     <ProjectType>Local</ProjectType>


### PR DESCRIPTION
For #118 
And fix null issues. Also includes removing reflection code across unit tests for type safety, removing ArrayList usage in favor or strongly typed lists, and a few opportunistic auto-properties and other modernizations.
New version of #119
@erikmav I've created a new branch and PR because I couldn't resolve the conflicts in the old one.