### PR TITLE
Correct version number in release notes

### DIFF
--- a/src/site/xdoc/release/release-notes.xml
+++ b/src/site/xdoc/release/release-notes.xml
@@ -28,7 +28,7 @@ limitations under the License.
 
     <section id="main" name="Apache log4net&#x2122; Release Notes">
       <section id="a2.0.17" name="2.0.17">
-        Apache log4net 2.0.16 addresses reported issues:
+        Apache log4net 2.0.17 addresses reported issues:
         <section id="a2.0.17-bug" name="Bug fixes">
           <ul>
             <li>


### PR DESCRIPTION
Hello

I noticed an issue on the Release Notes page which had the wrong version.

I have corrected this. Apologies if it's in the wrong place - I could find no other reference to it.

https://logging.apache.org/log4net/release/release-notes.html

![image](https://github.com/apache/logging-log4net/assets/23440/2acfd5d6-466d-4b91-8308-a75379704b8d)

Kind regards
Dan Atkinson