### PR TITLE
Update XmlLayoutSchemaLog4j.cs to set writer.Namespaces = true for NETSTANDARD

### DIFF
--- a/src/log4net/Layout/XmlLayoutSchemaLog4j.cs
+++ b/src/log4net/Layout/XmlLayoutSchemaLog4j.cs
@@ -138,6 +138,12 @@ method="run" file="Generator.java" line="94"/>
     /// </remarks>
     protected override void FormatXml(XmlWriter writer, LoggingEvent loggingEvent)
     {
+
+#if NETSTANDARD
+            // set namespaces to true for writer
+            ((System.Xml.XmlTextWriter)writer).Namespaces = true;
+#endif
+
       // Translate logging events for log4j
 
       // Translate hostname property


### PR DESCRIPTION
Formatting is off when using .NET 6+ when outing in Log2Console.