### PR TITLE
Fix empty string received by .NET 8 users on Linux on userName

### DIFF
--- a/src/log4net.Tests/Core/LoggingEventTest.cs
+++ b/src/log4net.Tests/Core/LoggingEventTest.cs
@@ -142,4 +142,15 @@ public sealed class LoggingEventTest
     static void AssertIsCurrentThreadId(string name)
       => Assert.That(SystemInfo.CurrentThreadId.ToString(CultureInfo.InvariantCulture), Is.EqualTo(name));
   }
+
+  [Test]
+  public void UserNameTest()
+  {
+    var expectedUserName =
+                Environment.OSVersion.VersionString.StartsWith("Microsoft Windows")?
+                  $"{Environment.UserDomainName}\\{Environment.UserName}"
+                : Environment.UserName;
+    var sut = new LoggingEvent();
+    Assert.AreEqual(expectedUserName, sut.UserName);
+  }
 }

--- a/src/log4net.Tests/Core/LoggingEventTest.cs
+++ b/src/log4net.Tests/Core/LoggingEventTest.cs
@@ -146,11 +146,11 @@ public sealed class LoggingEventTest
   [Test]
   public void UserNameTest()
   {
-    var expectedUserName =
+    string expectedUserName =
                 Environment.OSVersion.VersionString.StartsWith("Microsoft Windows")?
                   $"{Environment.UserDomainName}\\{Environment.UserName}"
                 : Environment.UserName;
-    var sut = new LoggingEvent();
-    Assert.AreEqual(expectedUserName, sut.UserName);
+    LoggingEvent sut = new();
+    Assert.That(sut.UserName, Is.EqualTo(expectedUserName));
   }
 }

--- a/src/log4net/Core/LoggingEvent.cs
+++ b/src/log4net/Core/LoggingEvent.cs
@@ -743,15 +743,15 @@ public class LoggingEvent : ILog4NetSerializable
 
   private string? TryGetCurrentUserName()
   {
-    if (_platformDoesNotSupportWindowsIdentity)
-    {
-      // we've already received one PlatformNotSupportedException or null from TryReadWindowsIdentityUserName
-      // and it's highly unlikely that will change
-      return Environment.UserName;
-    }
-
     try
     {
+      if (_platformDoesNotSupportWindowsIdentity)
+      {
+        // we've already received one PlatformNotSupportedException or null from TryReadWindowsIdentityUserName
+        // and it's highly unlikely that will change
+        return Environment.UserName;
+      }
+    
       if (_cachedWindowsIdentityUserName is not null)
       {
         return _cachedWindowsIdentityUserName;
@@ -788,14 +788,16 @@ public class LoggingEvent : ILog4NetSerializable
   private string? _cachedWindowsIdentityUserName;
   
   /// <returns>
-  ///  On Windows: UserName in case of success, empty string for null
+  ///  On Windows: UserName in case of success, empty string for unexpected null in identity or Name
   ///  <para/>
   ///  On other OSes: null
   /// </returns>
   /// <exception cref="PlatformNotSupportedException">Thrown on non-Windows platforms on net462</exception>
   private static string? TryReadWindowsIdentityUserName()
   {
-#if !NET462_OR_GREATER
+    // According to docs RuntimeInformation.IsOSPlatform is supported from netstandard1.1,
+    // but it's erroring in runtime on < net471
+#if NET471_OR_GREATER || NETSTANDARD2_0_OR_GREATER
     if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
     {
       return null;

--- a/src/log4net/Core/LoggingEvent.cs
+++ b/src/log4net/Core/LoggingEvent.cs
@@ -701,8 +701,8 @@ public class LoggingEvent : ILog4NetSerializable
   /// </value>
   /// <remarks>
   /// <para>
-  /// Calls <c>WindowsIdentity.GetCurrent().Name</c> to get the name of
-  /// the current windows user.
+  /// On Windows it calls <c>WindowsIdentity.GetCurrent().Name</c> to get the name of
+  /// the current windows user. On other OSes it calls Environment.UserName.
   /// </para>
   /// <para>
   /// To improve performance, we could cache the string representation of 
@@ -752,20 +752,17 @@ public class LoggingEvent : ILog4NetSerializable
 
     try
     {
-      if(_cachedWindowsIdentityUserName is not null)
+      if (_cachedWindowsIdentityUserName is not null)
       {
         return _cachedWindowsIdentityUserName;
       }
-      else if(TryReadWindowsIdentityUserName() is string userName)
+      if (TryReadWindowsIdentityUserName() is string userName)
       {
         _cachedWindowsIdentityUserName = userName;
         return _cachedWindowsIdentityUserName;
       }
-      else
-      {
-        _platformDoesNotSupportWindowsIdentity = true;
-        return Environment.UserName;
-      }
+      _platformDoesNotSupportWindowsIdentity = true;
+      return Environment.UserName;
     }
     catch (PlatformNotSupportedException)
     {

--- a/src/log4net/Core/LoggingEvent.cs
+++ b/src/log4net/Core/LoggingEvent.cs
@@ -787,10 +787,12 @@ public class LoggingEvent : ILog4NetSerializable
 
   private string? _cachedWindowsIdentityUserName;
   
-  /// <summary>
-  /// TODO
-  /// </summary>
-  /// <returns>TODO</returns>
+  /// <returns>
+  ///  On Windows: UserName in case of success, empty string for null
+  ///  <para/>
+  ///  On other OSes: null
+  /// </returns>
+  /// <exception cref="PlatformNotSupportedException">Thrown on non-Windows platforms on net462</exception>
   private static string? TryReadWindowsIdentityUserName()
   {
 #if !NET462_OR_GREATER


### PR DESCRIPTION
### Background
While working on getting log4net.Ext.Json package to work with log4net 3 I noticed a regression. With log4net 2.0.10  the test checking if the user name is as expected worked both during local run on my Windows machine and on the CI Linux agent used by Gitlab. After upgrading log4net to version 3.0.1 it stopped working on the CI and started reporting that the user name is an empty string.

Passing:
https://gitlab.com/gdziadkiewicz/log4net.Ext.Json/-/jobs/7522362244

Failing:
https://gitlab.com/gdziadkiewicz/log4net.Ext.Json/-/jobs/8094529032#L172

### Testing
It would be great to be able to run tests for log4net on all combinations of frameworks and OSes automatically (would you be interested in someone getting started work on it?).

In the meantime it draws as important for me to test (not sure about expected results yet):
* windows + net8 
* windows + net6
* windows + net461
* linux + net8
* linux + net6
* mac + net8
* mac + net6
* linux + mono
* mac + mono
* windows + mono

### Questions to answer before finalizing the change
1. Is WindowsIdentity Windows specific (name seems to suggest it)?
2. How is `Environment.User` implemented on different platforms? Does it change? Is it expensive? Would caching make sense?
3. Does and WindowsIdentity work on Mono on Win? If yes, how?
4. [RuntimeInformation.IsOSPlatform](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.isosplatform?view=netframework-4.7.1) is supported from net471, would reformulating the #if around it to communicate that help in the future?
