### PR TITLE
use raw strings for config files in unit tests

### DIFF
--- a/src/log4net.Tests/Appender/AdoNetAppenderTest.cs
+++ b/src/log4net.Tests/Appender/AdoNetAppenderTest.cs
@@ -87,7 +87,8 @@ public class AdoNetAppenderTest
   public void WebsiteExample()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
       <appender name="AdoNetAppender" type="log4net.Appender.AdoNetAppender">
           <bufferSize value="-1" />
@@ -143,7 +144,7 @@ public class AdoNetAppenderTest
           <appender-ref ref="AdoNetAppender" />
         </root>  
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -174,7 +175,8 @@ public class AdoNetAppenderTest
   public void BufferingWebsiteExample()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
       <appender name="AdoNetAppender" type="log4net.Appender.AdoNetAppender">
           <bufferSize value="2" />
@@ -230,7 +232,7 @@ public class AdoNetAppenderTest
           <appender-ref ref="AdoNetAppender" />
         </root>  
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -266,7 +268,8 @@ public class AdoNetAppenderTest
   public void NullPropertyXmlConfig()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
       <appender name="AdoNetAppender" type="log4net.Appender.AdoNetAppender">
           <bufferSize value="-1" />
@@ -287,7 +290,7 @@ public class AdoNetAppenderTest
           <appender-ref ref="AdoNetAppender" />
         </root>  
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);

--- a/src/log4net.Tests/Appender/AdoNetAppenderTest.cs
+++ b/src/log4net.Tests/Appender/AdoNetAppenderTest.cs
@@ -53,7 +53,7 @@ public class AdoNetAppenderTest
     ILog log = LogManager.GetLogger(rep.Name, "NoBufferingTest");
     log.Debug("Message");
     Assert.That(Log4NetCommand.MostRecentInstance, Is.Not.Null);
-    Assert.That(Log4NetCommand.MostRecentInstance!.ExecuteNonQueryCount, Is.EqualTo(1));
+    Assert.That(Log4NetCommand.MostRecentInstance.ExecuteNonQueryCount, Is.EqualTo(1));
   }
 
   [Test]
@@ -61,7 +61,7 @@ public class AdoNetAppenderTest
   {
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
 
-    int bufferSize = 5;
+    const int bufferSize = 5;
 
     AdoNetAppender adoNetAppender = new()
     {
@@ -80,69 +80,70 @@ public class AdoNetAppenderTest
     }
     log.Debug("Message");
     Assert.That(Log4NetCommand.MostRecentInstance, Is.Not.Null);
-    Assert.That(Log4NetCommand.MostRecentInstance!.ExecuteNonQueryCount, Is.EqualTo(bufferSize + 1));
+    Assert.That(Log4NetCommand.MostRecentInstance.ExecuteNonQueryCount, Is.EqualTo(bufferSize + 1));
   }
 
   [Test]
   public void WebsiteExample()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
-                <log4net>
-                <appender name=""AdoNetAppender"" type=""log4net.Appender.AdoNetAppender"">
-                    <bufferSize value=""-1"" />
-                    <connectionType value=""log4net.Tests.Appender.AdoNet.Log4NetConnection"" />
-                    <connectionString value=""data source=[database server];initial catalog=[database name];integrated security=false;persist security info=True;User ID=[user];Password=[password]"" />
-                    <commandText value=""INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message],[Exception]) VALUES (@log_date, @thread, @log_level, @logger, @message, @exception)"" />
-                    <parameter>
-                        <parameterName value=""@log_date"" />
-                        <dbType value=""DateTime"" />
-                        <layout type=""log4net.Layout.RawTimeStampLayout"" />
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@thread"" />
-                        <dbType value=""String"" />
-                        <size value=""255"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%thread"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@log_level"" />
-                        <dbType value=""String"" />
-                        <size value=""50"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%level"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@logger"" />
-                        <dbType value=""String"" />
-                        <size value=""255"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%logger"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@message"" />
-                        <dbType value=""String"" />
-                        <size value=""4000"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%message"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@exception"" />
-                        <dbType value=""String"" />
-                        <size value=""2000"" />
-                        <layout type=""log4net.Layout.ExceptionLayout"" />
-                    </parameter>
-                </appender>
-                <root>
-                    <level value=""ALL"" />
-                    <appender-ref ref=""AdoNetAppender"" />
-                  </root>  
-                </log4net>");
+    log4NetConfig.LoadXml("""
+      <log4net>
+      <appender name="AdoNetAppender" type="log4net.Appender.AdoNetAppender">
+          <bufferSize value="-1" />
+          <connectionType value="log4net.Tests.Appender.AdoNet.Log4NetConnection" />
+          <connectionString value="data source=[database server];initial catalog=[database name];integrated security=false;persist security info=True;User ID=[user];Password=[password]" />
+          <commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message],[Exception]) VALUES (@log_date, @thread, @log_level, @logger, @message, @exception)" />
+          <parameter>
+              <parameterName value="@log_date" />
+              <dbType value="DateTime" />
+              <layout type="log4net.Layout.RawTimeStampLayout" />
+          </parameter>
+          <parameter>
+              <parameterName value="@thread" />
+              <dbType value="String" />
+              <size value="255" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%thread" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@log_level" />
+              <dbType value="String" />
+              <size value="50" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%level" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@logger" />
+              <dbType value="String" />
+              <size value="255" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%logger" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@message" />
+              <dbType value="String" />
+              <size value="4000" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%message" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@exception" />
+              <dbType value="String" />
+              <size value="2000" />
+              <layout type="log4net.Layout.ExceptionLayout" />
+          </parameter>
+      </appender>
+      <root>
+          <level value="ALL" />
+          <appender-ref ref="AdoNetAppender" />
+        </root>  
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -173,62 +174,63 @@ public class AdoNetAppenderTest
   public void BufferingWebsiteExample()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
-                <log4net>
-                <appender name=""AdoNetAppender"" type=""log4net.Appender.AdoNetAppender"">
-                    <bufferSize value=""2"" />
-                    <connectionType value=""log4net.Tests.Appender.AdoNet.Log4NetConnection"" />
-                    <connectionString value=""data source=[database server];initial catalog=[database name];integrated security=false;persist security info=True;User ID=[user];Password=[password]"" />
-                    <commandText value=""INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message],[Exception]) VALUES (@log_date, @thread, @log_level, @logger, @message, @exception)"" />
-                    <parameter>
-                        <parameterName value=""@log_date"" />
-                        <dbType value=""DateTime"" />
-                        <layout type=""log4net.Layout.RawTimeStampLayout"" />
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@thread"" />
-                        <dbType value=""String"" />
-                        <size value=""255"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%thread"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@log_level"" />
-                        <dbType value=""String"" />
-                        <size value=""50"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%level"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@logger"" />
-                        <dbType value=""String"" />
-                        <size value=""255"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%logger"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@message"" />
-                        <dbType value=""String"" />
-                        <size value=""4000"" />
-                        <layout type=""log4net.Layout.PatternLayout"">
-                            <conversionPattern value=""%message"" />
-                        </layout>
-                    </parameter>
-                    <parameter>
-                        <parameterName value=""@exception"" />
-                        <dbType value=""String"" />
-                        <size value=""2000"" />
-                        <layout type=""log4net.Layout.ExceptionLayout"" />
-                    </parameter>
-                </appender>
-                <root>
-                    <level value=""ALL"" />
-                    <appender-ref ref=""AdoNetAppender"" />
-                  </root>  
-                </log4net>");
+    log4NetConfig.LoadXml("""
+      <log4net>
+      <appender name="AdoNetAppender" type="log4net.Appender.AdoNetAppender">
+          <bufferSize value="2" />
+          <connectionType value="log4net.Tests.Appender.AdoNet.Log4NetConnection" />
+          <connectionString value="data source=[database server];initial catalog=[database name];integrated security=false;persist security info=True;User ID=[user];Password=[password]" />
+          <commandText value="INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message],[Exception]) VALUES (@log_date, @thread, @log_level, @logger, @message, @exception)" />
+          <parameter>
+              <parameterName value="@log_date" />
+              <dbType value="DateTime" />
+              <layout type="log4net.Layout.RawTimeStampLayout" />
+          </parameter>
+          <parameter>
+              <parameterName value="@thread" />
+              <dbType value="String" />
+              <size value="255" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%thread" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@log_level" />
+              <dbType value="String" />
+              <size value="50" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%level" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@logger" />
+              <dbType value="String" />
+              <size value="255" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%logger" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@message" />
+              <dbType value="String" />
+              <size value="4000" />
+              <layout type="log4net.Layout.PatternLayout">
+                  <conversionPattern value="%message" />
+              </layout>
+          </parameter>
+          <parameter>
+              <parameterName value="@exception" />
+              <dbType value="String" />
+              <size value="2000" />
+              <layout type="log4net.Layout.ExceptionLayout" />
+          </parameter>
+      </appender>
+      <root>
+          <level value="ALL" />
+          <appender-ref ref="AdoNetAppender" />
+        </root>  
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -242,7 +244,7 @@ public class AdoNetAppenderTest
     IDbCommand? command = Log4NetCommand.MostRecentInstance;
     Assert.That(command, Is.Not.Null);
 
-    Assert.That(command!.CommandText,
+    Assert.That(command.CommandText,
      Is.EqualTo("INSERT INTO Log ([Date],[Thread],[Level],[Logger],[Message],[Exception]) VALUES (@log_date, @thread, @log_level, @logger, @message, @exception)"));
 
     Assert.That(command.Parameters, Has.Count.EqualTo(6));
@@ -264,27 +266,28 @@ public class AdoNetAppenderTest
   public void NullPropertyXmlConfig()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
-                <log4net>
-                <appender name=""AdoNetAppender"" type=""log4net.Appender.AdoNetAppender"">
-                    <bufferSize value=""-1"" />
-                    <connectionType value=""log4net.Tests.Appender.AdoNet.Log4NetConnection"" />
-                    <connectionString value=""data source=[database server];initial catalog=[database name];integrated security=false;persist security info=True;User ID=[user];Password=[password]"" />
-                    <commandText value=""INSERT INTO Log ([ProductId]) VALUES (@productId)"" />
-                    <parameter>
-                        <parameterName value=""@productId"" />
-                        <dbType value=""String"" />
-                        <size value=""50"" />
-                        <layout type="" log4net.Layout.RawPropertyLayout"">
-                           <key value=""ProductId"" />
-                        </layout>
-                    </parameter>                    
-                </appender>
-                <root>
-                    <level value=""ALL"" />
-                    <appender-ref ref=""AdoNetAppender"" />
-                  </root>  
-                </log4net>");
+    log4NetConfig.LoadXml("""
+      <log4net>
+      <appender name="AdoNetAppender" type="log4net.Appender.AdoNetAppender">
+          <bufferSize value="-1" />
+          <connectionType value="log4net.Tests.Appender.AdoNet.Log4NetConnection" />
+          <connectionString value="data source=[database server];initial catalog=[database name];integrated security=false;persist security info=True;User ID=[user];Password=[password]" />
+          <commandText value="INSERT INTO Log ([ProductId]) VALUES (@productId)" />
+          <parameter>
+              <parameterName value="@productId" />
+              <dbType value="String" />
+              <size value="50" />
+              <layout type=" log4net.Layout.RawPropertyLayout">
+                 <key value="ProductId" />
+              </layout>
+          </parameter>                    
+      </appender>
+      <root>
+          <level value="ALL" />
+          <appender-ref ref="AdoNetAppender" />
+        </root>  
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -294,7 +297,7 @@ public class AdoNetAppenderTest
     IDbCommand? command = Log4NetCommand.MostRecentInstance;
     Assert.That(command, Is.Not.Null);
 
-    IDbDataParameter param = (IDbDataParameter)command!.Parameters["@productId"];
+    IDbDataParameter param = (IDbDataParameter)command.Parameters["@productId"];
     Assert.That(param.Value, Is.Not.EqualTo(SystemInfo.NullText));
     Assert.That(param.Value, Is.EqualTo(DBNull.Value));
   }
@@ -331,7 +334,7 @@ public class AdoNetAppenderTest
     IDbCommand? command = Log4NetCommand.MostRecentInstance;
     Assert.That(command, Is.Not.Null);
 
-    IDbDataParameter param = (IDbDataParameter)command!.Parameters["@productId"];
+    IDbDataParameter param = (IDbDataParameter)command.Parameters["@productId"];
     Assert.That(param.Value, Is.Not.EqualTo(SystemInfo.NullText));
     Assert.That(param.Value, Is.EqualTo(DBNull.Value));
   }

--- a/src/log4net.Tests/Appender/AppenderCollectionTest.cs
+++ b/src/log4net.Tests/Appender/AppenderCollectionTest.cs
@@ -38,7 +38,7 @@ public class AppenderCollectionTest
   [Test]
   public void ToArrayTest()
   {
-    AppenderCollection appenderCollection = new();
+    AppenderCollection appenderCollection = [];
     IAppender appender = new MemoryAppender();
     appenderCollection.Add(appender);
 
@@ -51,7 +51,7 @@ public class AppenderCollectionTest
   [Test]
   public void ReadOnlyToArrayTest()
   {
-    AppenderCollection appenderCollection = new();
+    AppenderCollection appenderCollection = [];
     IAppender appender = new MemoryAppender();
     appenderCollection.Add(appender);
     AppenderCollection readonlyAppenderCollection = AppenderCollection.ReadOnly(appenderCollection);

--- a/src/log4net.Tests/Appender/FileAppenderTest.cs
+++ b/src/log4net.Tests/Appender/FileAppenderTest.cs
@@ -72,27 +72,28 @@ public sealed class FileAppenderTest
     try
     {
       XmlDocument log4NetConfig = new();
-      log4NetConfig.LoadXml("""
-  <log4net>
-    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
-      </layout>
-    </appender>
-    <appender name="GeneralFileAppender" type="log4net.Appender.FileAppender">
-      <file type="log4net.Util.PatternString" value="Logs\file_%property{LogName}_%date{yyyyMMddHHmmss}.Log"/>
-      <appendToFile value="true"/>
-      <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
-      </layout>
-    </appender>
-    <root>
-      <level value="INFO"/>
-      <appender-ref ref="GeneralFileAppender"/>
-    </root>
-  </log4net>
-""");
+      log4NetConfig.LoadXml(
+        """
+        <log4net>
+          <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+            <layout type="log4net.Layout.PatternLayout">
+              <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
+            </layout>
+          </appender>
+          <appender name="GeneralFileAppender" type="log4net.Appender.FileAppender">
+            <file type="log4net.Util.PatternString" value="Logs\file_%property{LogName}_%date{yyyyMMddHHmmss}.Log"/>
+            <appendToFile value="true"/>
+            <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
+            <layout type="log4net.Layout.PatternLayout">
+              <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
+            </layout>
+          </appender>
+          <root>
+            <level value="INFO"/>
+            <appender-ref ref="GeneralFileAppender"/>
+          </root>
+        </log4net>
+        """);
       ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
       XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
     }
@@ -119,27 +120,28 @@ public sealed class FileAppenderTest
     }
 
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
-  <log4net>
-    <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
-      </layout>
-    </appender>
-    <appender name="GeneralFileAppender" type="log4net.Appender.FileAppender">
-      <file type="log4net.Util.PatternString" value="Logs\file_%property{LogName}_%date{yyyyMMddHHmmss}.Log"/>
-      <appendToFile value="true"/>
-      <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
-      <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
-      </layout>
-    </appender>
-    <root>
-      <level value="INFO"/>
-      <appender-ref ref="GeneralFileAppender"/>
-    </root>
-  </log4net>
-""");
+    log4NetConfig.LoadXml(
+      """
+      <log4net>
+        <appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+          <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
+          </layout>
+        </appender>
+        <appender name="GeneralFileAppender" type="log4net.Appender.FileAppender">
+          <file type="log4net.Util.PatternString" value="Logs\file_%property{LogName}_%date{yyyyMMddHHmmss}.Log"/>
+          <appendToFile value="true"/>
+          <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
+          <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date{ABSOLUTE} [%logger] %level - %message%newline%exception"/>
+          </layout>
+        </appender>
+        <root>
+          <level value="INFO"/>
+          <appender-ref ref="GeneralFileAppender"/>
+        </root>
+      </log4net>
+      """);
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     // latest possible moment to set GlobalContext property used in filename
     GlobalContext.Properties["LogName"] = "custom_log_issue_193";

--- a/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
+++ b/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
@@ -32,6 +32,7 @@ using log4net.Repository.Hierarchy;
 using log4net.Util;
 using NUnit.Framework;
 using System.Globalization;
+using System.Linq;
 
 namespace log4net.Tests.Appender;
 
@@ -448,15 +449,15 @@ public sealed class RollingFileAppenderTest
   private void LogMessage(string sMessageToLog)
   {
     Assert.That(_caRoot, Is.Not.Null);
-    Assert.That(_messagesLogged++, Is.EqualTo(_caRoot!.Counter));
+    Assert.That(_messagesLogged++, Is.EqualTo(_caRoot.Counter));
     Assert.That(_root, Is.Not.Null);
-    _root!.Log(Level.Debug, sMessageToLog, null);
+    _root.Log(Level.Debug, sMessageToLog, null);
     Assert.That(_messagesLogged, Is.EqualTo(_caRoot.Counter));
   }
 
   /// <summary>
   /// Runs through all table entries, logging messages.  Before each message is logged,
-  /// pre-conditions are checked to ensure the expected files exist and they are the
+  /// pre-conditions are checked to ensure the expected files exists, and they are the
   /// expected size.  After logging, verifies the same.
   /// </summary>
   /// <param name="sBaseFileName"></param>
@@ -464,10 +465,8 @@ public sealed class RollingFileAppenderTest
   /// <param name="sMessageToLog"></param>
   private void RollFromTableEntries(string sBaseFileName, RollConditions[] entries, string sMessageToLog)
   {
-    for (int i = 0; i < entries.Length; i++)
+    foreach (RollConditions entry in entries)
     {
-      RollConditions entry = entries[i];
-
       VerifyPreConditions(sBaseFileName, entry);
       LogMessage(sMessageToLog);
       VerifyPostConditions(sBaseFileName, entry);
@@ -524,23 +523,10 @@ public sealed class RollingFileAppenderTest
   /// <param name="sBackupGroup"></param>
   /// <param name="iBackupFileLength"></param>
   /// <returns></returns>
-  private static List<RollFileEntry> MakeBackupFileEntriesFromBackupGroup(string sBackupGroup, int iBackupFileLength)
-  {
-    string[] sFiles = sBackupGroup.Split(' ');
-
-    List<RollFileEntry> result = [];
-
-    for (int i = 0; i < sFiles.Length; i++)
-    {
-      // Weed out any whitespace entries from the array
-      if (sFiles[i].Trim().Length > 0)
-      {
-        result.Add(new RollFileEntry(sFiles[i], iBackupFileLength));
-      }
-    }
-
-    return result;
-  }
+  private static List<RollFileEntry> MakeBackupFileEntriesFromBackupGroup(string sBackupGroup, int iBackupFileLength) 
+    => sBackupGroup.Split(' ').Where(file => file.Trim().Length > 0)
+      .Select(file => new RollFileEntry(file, iBackupFileLength))
+      .ToList();
 
   /// <summary>
   /// Finds the iGroup group in the string (comma separated groups)
@@ -611,7 +597,7 @@ public sealed class RollingFileAppenderTest
 
   /// <summary>
   /// The stats are used to keep track of progress while we are algorithmically
-  /// generating a table of pre/post condition tests for file rolling.
+  /// generating a table of pre- / post-condition tests for file rolling.
   /// </summary>
   /// <param name="sTestMessage"></param>
   /// <returns></returns>
@@ -656,7 +642,7 @@ public sealed class RollingFileAppenderTest
   }
 
   /// <summary>
-  /// Generates the pre and post condition arrays from an array of backup files and the
+  /// Generates the pre- and post-condition arrays from an array of backup files and the
   /// current file / next file.
   /// </summary>
   private static RollConditions BuildTableEntry(string sBackupFiles,
@@ -735,7 +721,7 @@ public sealed class RollingFileAppenderTest
   /// <summary>
   /// This routine takes a list of backup file names and a message that will be logged
   /// repeatedly, and generates a collection of objects containing pre-condition and 
-  /// post-condition information.  This pre/post information shows the names and expected 
+  /// post-condition information.  This pre- / post-information shows the names and expected 
   /// file sizes for all files just before and just after a message is logged.
   /// </summary>
   /// <param name="sTestMessage">A message to log repeatedly</param>
@@ -880,7 +866,7 @@ public sealed class RollingFileAppenderTest
     // Oldest to newest when reading in a group left-to-right, so 1 2 3 means 1 is the
     // oldest, and 3 is the newest
     //
-    string sBackupInfo = ", , , , ";
+    const string sBackupInfo = ", , , , ";
 
     //
     // Count Up
@@ -896,7 +882,7 @@ public sealed class RollingFileAppenderTest
     // Log 30 messages.  This is 5 groups, 6 checks per group ( 0, 100, 200, 300, 400, 500 
     // bytes for current file as messages are logged.
     //
-    int iMessagesToLog = 30;
+    const int iMessagesToLog = 30;
 
     VerifyRolling(MakeNumericTestEntries(GetTestMessage(), sBackupInfo, iMessagesToLog));
   }
@@ -914,7 +900,7 @@ public sealed class RollingFileAppenderTest
     // Oldest to newest when reading in a group left-to-right, so 1 2 3 means 1 is the
     // oldest, and 3 is the newest
     //
-    string sBackupInfo = "1, 1 2, 1 2 3, 1 2 3, 1 2 3";
+    const string sBackupInfo = "1, 1 2, 1 2 3, 1 2 3, 1 2 3";
 
     //
     // Count Up
@@ -925,7 +911,7 @@ public sealed class RollingFileAppenderTest
     // Log 30 messages.  This is 5 groups, 6 checks per group ( 0, 100, 200, 300, 400, 500 
     // bytes for current file as messages are logged.
     //
-    int iMessagesToLog = 30;
+    const int iMessagesToLog = 30;
 
     VerifyRolling(MakeNumericTestEntries(GetTestMessage(), sBackupInfo, iMessagesToLog));
   }
@@ -943,7 +929,7 @@ public sealed class RollingFileAppenderTest
     // Oldest to newest when reading in a group left-to-right, so 1 2 3 means 1 is the
     // oldest, and 3 is the newest
     //
-    string sBackupInfo = "1, 1 2, 1 2 3, 1 2 3 4, 1 2 3 4 5";
+    const string sBackupInfo = "1, 1 2, 1 2 3, 1 2 3 4, 1 2 3 4 5";
 
     //
     // Count Down
@@ -959,7 +945,7 @@ public sealed class RollingFileAppenderTest
     // Log 30 messages.  This is 5 groups, 6 checks per group ( 0, 100, 200, 300, 400, 500 
     // bytes for current file as messages are logged.
     //
-    int iMessagesToLog = 30;
+    const int iMessagesToLog = 30;
 
     VerifyRolling(MakeNumericTestEntries(GetTestMessage(), sBackupInfo, iMessagesToLog));
   }
@@ -976,7 +962,7 @@ public sealed class RollingFileAppenderTest
     // Oldest to newest when reading in a group left-to-right, so 1 2 3 means 1 is the
     // oldest, and 3 is the newest
     //
-    string sBackupInfo = ", , , , ";
+    const string sBackupInfo = ", , , , ";
 
     //
     // Count Up
@@ -992,7 +978,7 @@ public sealed class RollingFileAppenderTest
     // Log 30 messages.  This is 5 groups, 6 checks per group ( 0, 100, 200, 300, 400, 500 
     // bytes for current file as messages are logged.
     //
-    int iMessagesToLog = 30;
+    const int iMessagesToLog = 30;
 
     VerifyRolling(MakeNumericTestEntries(GetTestMessage(), sBackupInfo, iMessagesToLog));
   }
@@ -1037,7 +1023,7 @@ public sealed class RollingFileAppenderTest
   [Test]
   public void TestInitializeRollBackups1()
   {
-    string sBaseFile = "LogFile.log";
+    const string sBaseFile = "LogFile.log";
     List<string> arrFiles =
     [
       "junk1",
@@ -1047,7 +1033,7 @@ public sealed class RollingFileAppenderTest
       "junk.log.2",
     ];
 
-    int iExpectedCurSizeRollBackups = 0;
+    const int iExpectedCurSizeRollBackups = 0;
     VerifyInitializeRollBackupsFromBaseFile(sBaseFile, arrFiles, iExpectedCurSizeRollBackups);
   }
 
@@ -1059,7 +1045,7 @@ public sealed class RollingFileAppenderTest
   {
     List<string> alFiles = MakeTestDataFromString(sBaseFile, "0,1,2");
 
-    int iExpectedCurSizeRollBackups = 2;
+    const int iExpectedCurSizeRollBackups = 2;
     VerifyInitializeRollBackupsFromBaseFile(sBaseFile, alFiles, iExpectedCurSizeRollBackups);
   }
 
@@ -1070,7 +1056,7 @@ public sealed class RollingFileAppenderTest
   public void TestInitializeCountUpFixed()
   {
     List<string> alFiles = MakeTestDataFromString("3,4,5");
-    int iExpectedValue = 5;
+    const int iExpectedValue = 5;
     InitializeAndVerifyExpectedValue(alFiles, FileName, CreateRollingFileAppender("3,0,1"), iExpectedValue);
   }
 
@@ -1081,7 +1067,7 @@ public sealed class RollingFileAppenderTest
   public void TestInitializeCountUpFixed2()
   {
     List<string> alFiles = MakeTestDataFromString("0,3");
-    int iExpectedValue = 3;
+    const int iExpectedValue = 3;
     InitializeAndVerifyExpectedValue(alFiles, FileName, CreateRollingFileAppender("3,0,1"), iExpectedValue);
   }
 
@@ -1093,7 +1079,7 @@ public sealed class RollingFileAppenderTest
   public void TestInitializeCountUpZeroBackups()
   {
     List<string> alFiles = MakeTestDataFromString("0,3");
-    int iExpectedValue = 0;
+    const int iExpectedValue = 0;
     InitializeAndVerifyExpectedValue(alFiles, FileName, CreateRollingFileAppender("0,0,1"), iExpectedValue);
   }
 
@@ -1105,7 +1091,7 @@ public sealed class RollingFileAppenderTest
   public void TestInitializeCountDownZeroBackups()
   {
     List<string> alFiles = MakeTestDataFromString("0,3");
-    int iExpectedValue = 0;
+    const int iExpectedValue = 0;
     InitializeAndVerifyExpectedValue(alFiles, FileName, CreateRollingFileAppender("0,0,-1"), iExpectedValue);
   }
 
@@ -1188,7 +1174,7 @@ public sealed class RollingFileAppenderTest
   }
 
   /// <summary>
-  /// Tests the count down case, with infinite max backups, to see that
+  /// Tests the count-down case, with infinite max backups, to see that
   /// initialization of the rolling file appender results in the expected value
   /// </summary>
   /// <param name="alFiles"></param>
@@ -1353,8 +1339,8 @@ public sealed class RollingFileAppenderTest
 
   private static void AssertFileEquals(string filename, string contents)
   {
-    string logcont = File.ReadAllText(filename);
-    Assert.That(logcont, Is.EqualTo(contents), "Log contents is not what is expected");
+    string logContent = File.ReadAllText(filename);
+    Assert.That(logContent, Is.EqualTo(contents), "Log contents is not what is expected");
     File.Delete(filename);
   }
 
@@ -1365,7 +1351,7 @@ public sealed class RollingFileAppenderTest
   public void TestLogOutput()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_simple.log";
+    const string filename = "test_simple.log";
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, new FileAppender.ExclusiveLock(), sh);
     log.Log(GetType(), Level.Info, "This is a message", null);
@@ -1373,7 +1359,7 @@ public sealed class RollingFileAppenderTest
     DestroyLogger();
 
     AssertFileEquals(filename,
-        "This is a message" + Environment.NewLine + "This is a message 2" + Environment.NewLine);
+      "This is a message" + Environment.NewLine + "This is a message 2" + Environment.NewLine);
     Assert.That(sh.Message, Is.EqualTo(""), "Unexpected error message");
   }
 
@@ -1383,10 +1369,10 @@ public sealed class RollingFileAppenderTest
   [Test]
   public void TestExclusiveLockFails()
   {
-    string filename = "test_exclusive_lock_fails.log";
+    const string filename = "test_exclusive_lock_fails.log";
 
     FileStream fs = new(filename, FileMode.Create, FileAccess.Write, FileShare.None);
-    fs.Write(Encoding.ASCII.GetBytes("Test"), 0, 4);
+    fs.Write("Test"u8.ToArray(), 0, 4);
 
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, new FileAppender.ExclusiveLock(), sh);
@@ -1406,10 +1392,10 @@ public sealed class RollingFileAppenderTest
   public void TestExclusiveLockRecovers()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_exclusive_lock_recovers.log";
+    const string filename = "test_exclusive_lock_recovers.log";
 
     FileStream fs = new(filename, FileMode.Create, FileAccess.Write, FileShare.None);
-    fs.Write(Encoding.ASCII.GetBytes("Test"), 0, 4);
+    fs.Write("Test"u8.ToArray(), 0, 4);
 
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, new FileAppender.ExclusiveLock(), sh);
@@ -1430,7 +1416,7 @@ public sealed class RollingFileAppenderTest
   public void TestExclusiveLockLocks()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_exclusive_lock_locks.log";
+    const string filename = "test_exclusive_lock_locks.log";
     bool locked = false;
 
     SilentErrorHandler sh = new();
@@ -1440,7 +1426,7 @@ public sealed class RollingFileAppenderTest
     try
     {
       FileStream fs = new(filename, FileMode.Create, FileAccess.Write, FileShare.None);
-      fs.Write(Encoding.ASCII.GetBytes("Test"), 0, 4);
+      fs.Write("Test"u8.ToArray(), 0, 4);
       fs.Close();
     }
     catch (IOException e1)
@@ -1467,10 +1453,10 @@ public sealed class RollingFileAppenderTest
   public void TestMinimalLockFails()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_minimal_lock_fails.log";
+    const string filename = "test_minimal_lock_fails.log";
 
     FileStream fs = new(filename, FileMode.Create, FileAccess.Write, FileShare.None);
-    fs.Write(Encoding.ASCII.GetBytes("Test"), 0, 4);
+    fs.Write("Test"u8.ToArray(), 0, 4);
 
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, new FileAppender.MinimalLock(), sh);
@@ -1491,10 +1477,10 @@ public sealed class RollingFileAppenderTest
   public void TestMinimalLockRecovers()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_minimal_lock_recovers.log";
+    const string filename = "test_minimal_lock_recovers.log";
 
     FileStream fs = new(filename, FileMode.Create, FileAccess.Write, FileShare.None);
-    fs.Write(Encoding.ASCII.GetBytes("Test"), 0, 4);
+    fs.Write("Test"u8.ToArray(), 0, 4);
 
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, new FileAppender.MinimalLock(), sh);
@@ -1515,7 +1501,7 @@ public sealed class RollingFileAppenderTest
   public void TestMinimalLockUnlocks()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_minimal_lock_unlocks.log";
+    const string filename = "test_minimal_lock_unlocks.log";
     bool locked;
 
     SilentErrorHandler sh = new();
@@ -1544,10 +1530,10 @@ public sealed class RollingFileAppenderTest
   public void TestInterProcessLockFails()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_interprocess_lock_fails.log";
+    const string filename = "test_interprocess_lock_fails.log";
 
     FileStream fs = new(filename, FileMode.Create, FileAccess.Write, FileShare.None);
-    fs.Write(Encoding.ASCII.GetBytes("Test"), 0, 4);
+    fs.Write("Test"u8.ToArray(), 0, 4);
 
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, new FileAppender.InterProcessLock(), sh);
@@ -1568,10 +1554,10 @@ public sealed class RollingFileAppenderTest
   public void TestInterProcessLockRecovers()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_interprocess_lock_recovers.log";
+    const string filename = "test_interprocess_lock_recovers.log";
 
     FileStream fs = new(filename, FileMode.Create, FileAccess.Write, FileShare.None);
-    fs.Write(Encoding.ASCII.GetBytes("Test"), 0, 4);
+    fs.Write("Test"u8.ToArray(), 0, 4);
 
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, new FileAppender.InterProcessLock(), sh);
@@ -1592,7 +1578,7 @@ public sealed class RollingFileAppenderTest
   public void TestInterProcessLockUnlocks()
   {
     Utils.InconclusiveOnMono();
-    string filename = "test_interprocess_lock_unlocks.log";
+    const string filename = "test_interprocess_lock_unlocks.log";
     bool locked;
 
     SilentErrorHandler sh = new();
@@ -1642,7 +1628,7 @@ public sealed class RollingFileAppenderTest
   [Test]
   public void TestDefaultLockingModel()
   {
-    string filename = "test_default.log";
+    const string filename = "test_default.log";
 
     SilentErrorHandler sh = new();
     ILogger log = CreateLogger(filename, null, sh);
@@ -1695,19 +1681,9 @@ public sealed class RollingFileAppenderTest
   /// <param name="sFileName">Name of file to combine with numbers when generating counted file names</param>
   /// <param name="sFileNumbers">Comma separated list of numbers for counted file names</param>
   /// <returns></returns>
-  private static List<string> MakeTestDataFromString(string sFileName, string sFileNumbers)
-  {
-    List<string> alFiles = [];
-
-    string[] sNumbers = sFileNumbers.Split(',');
-    foreach (string sNumber in sNumbers)
-    {
-      int iValue = int.Parse(sNumber.Trim());
-      alFiles.Add(MakeFileName(sFileName, iValue));
-    }
-
-    return alFiles;
-  }
+  private static List<string> MakeTestDataFromString(string sFileName, string sFileNumbers) 
+    => sFileNumbers.Split(',').Select(sNumber => int.Parse(sNumber.Trim()))
+      .Select(iValue => MakeFileName(sFileName, iValue)).ToList();
 
   /// <summary>
   /// Tests that the current backup index is correctly detected
@@ -1729,8 +1705,8 @@ public sealed class RollingFileAppenderTest
   /// </summary>
   private static void VerifyInitializeRollBackups(int iBackups, int iMaxSizeRollBackups)
   {
-    string sBaseFile = "LogFile.log";
-    var arrFiles = new List<string> { "junk1" };
+    const string sBaseFile = "LogFile.log";
+    List<string> arrFiles = ["junk1"];
     for (int i = 0; i < iBackups; i++)
     {
       arrFiles.Add(MakeFileName(sBaseFile, i));
@@ -1749,14 +1725,9 @@ public sealed class RollingFileAppenderTest
     // 1 = file.log
     // 2 = file.log.1
     // 3 = file.log.2
-    if (iBackups is 0 or 1)
-    {
-      Assert.That(rfa.CurrentSizeRollBackups, Is.EqualTo(0));
-    }
-    else
-    {
-      Assert.That(rfa.CurrentSizeRollBackups, Is.EqualTo(Math.Min(iBackups - 1, iMaxSizeRollBackups)));
-    }
+    Assert.That(rfa.CurrentSizeRollBackups, iBackups is 0 or 1 
+      ? Is.EqualTo(0) 
+      : Is.EqualTo(Math.Min(iBackups - 1, iMaxSizeRollBackups)));
   }
 
   /// <summary>
@@ -1784,11 +1755,7 @@ public sealed class RollingFileAppenderTest
   /// when it has not also been initialized with ActivateOptions().
   /// </summary>
   [Test]
-  public void TestCreateCloseNoActivateOptions()
-  {
-    var appender = new RollingFileAppender();
-    appender.Close();
-  }
+  public void TestCreateCloseNoActivateOptions() => new RollingFileAppender().Close();
 
   //
   // Helper functions to dig into the appender

--- a/src/log4net.Tests/Appender/TelnetAppenderTest.cs
+++ b/src/log4net.Tests/Appender/TelnetAppenderTest.cs
@@ -50,20 +50,21 @@ public sealed class TelnetAppenderTest
 
     XmlDocument log4NetConfig = new();
     int port = 9090;
-    log4NetConfig.LoadXml($"""
-    <log4net>
-      <appender name="TelnetAppender" type="log4net.Appender.TelnetAppender">
-        <port value="{port}" />
-        <layout type="log4net.Layout.PatternLayout">
-          <conversionPattern value="%date %-5level - %message%newline" />
-        </layout>
-      </appender>
-      <root>
-        <level value="INFO"/>
-        <appender-ref ref="TelnetAppender"/>
-      </root>
-    </log4net>
-""");
+    log4NetConfig.LoadXml(
+      $"""
+      <log4net>
+        <appender name="TelnetAppender" type="log4net.Appender.TelnetAppender">
+          <port value="{port}" />
+          <layout type="log4net.Layout.PatternLayout">
+            <conversionPattern value="%date %-5level - %message%newline" />
+          </layout>
+        </appender>
+        <root>
+          <level value="INFO"/>
+          <appender-ref ref="TelnetAppender"/>
+        </root>
+      </log4net>
+      """);
     string logId = Guid.NewGuid().ToString();
     ILoggerRepository repository = LogManager.CreateRepository(logId);
     XmlConfigurator.Configure(repository, log4NetConfig["log4net"]!);

--- a/src/log4net.Tests/Appender/TraceAppenderTest.cs
+++ b/src/log4net.Tests/Appender/TraceAppenderTest.cs
@@ -79,9 +79,8 @@ public class TraceAppenderTest
     ILog log = LogManager.GetLogger(rep.Name, GetType());
     log.Debug("Message");
 
-    Assert.That(
-        categoryTraceListener.Category,
-        Is.EqualTo(MethodInfo.GetCurrentMethod()!.Name));
+    Assert.That(categoryTraceListener.Category,
+      Is.EqualTo(MethodBase.GetCurrentMethod()!.Name));
   }
 }
 
@@ -92,10 +91,7 @@ public class CategoryTraceListener : TraceListener
     // empty
   }
 
-  public override void WriteLine(string? message)
-  {
-    Write(message);
-  }
+  public override void WriteLine(string? message) => Write(message);
 
   public override void Write(string? message, string? category)
   {

--- a/src/log4net.Tests/Context/LogicalThreadContextTest.cs
+++ b/src/log4net.Tests/Context/LogicalThreadContextTest.cs
@@ -319,7 +319,7 @@ public class LogicalThreadContextTest
 
   private static async Task<string> SomeWorkStack(string stackName)
   {
-    var stringAppender = new StringAppender
+    StringAppender stringAppender = new()
     {
       Layout = new PatternLayout("%property{" + Utils.PropertyKey + "}")
     };
@@ -332,7 +332,7 @@ public class LogicalThreadContextTest
     using (LogicalThreadContext.Stacks[Utils.PropertyKey].Push(stackName))
     {
       log.Info("TestMessage");
-      Assert.That(stringAppender.GetString(), Is.EqualTo(string.Format("Outer {0}", stackName)), "Test logical thread stack value set");
+      Assert.That(stringAppender.GetString(), Is.EqualTo($"Outer {stackName}"), "Test logical thread stack value set");
       stringAppender.Reset();
 
       await MoreWorkStack(log, "A").ConfigureAwait(false);

--- a/src/log4net.Tests/Core/FixingTest.cs
+++ b/src/log4net.Tests/Core/FixingTest.cs
@@ -67,7 +67,7 @@ public class FixingTest
     // Arrange
     // Act
     var allFlags = Enum.GetValues(typeof(FixFlags)).Cast<FixFlags>()
-      .Except(new[] { FixFlags.None })
+      .Except([FixFlags.None])
       .ToArray();
     // Assert
     foreach (var flag in allFlags)
@@ -88,7 +88,7 @@ public class FixingTest
       loggingEventData.LoggerName,
       loggingEventData.Level,
       loggingEventData.Message,
-      new Exception("This is the exception"));
+      new("This is the exception"));
 
     AssertExpectedLoggingEvent(loggingEvent, loggingEventData);
 
@@ -107,7 +107,7 @@ public class FixingTest
       loggingEventData.LoggerName,
       loggingEventData.Level,
       loggingEventData.Message,
-      new Exception("This is the exception"));
+      new("This is the exception"));
 
     AssertExpectedLoggingEvent(loggingEvent, loggingEventData);
 
@@ -128,7 +128,7 @@ public class FixingTest
       loggingEventData.LoggerName,
       loggingEventData.Level,
       loggingEventData.Message,
-      new Exception("This is the exception"));
+      new("This is the exception"));
 
     AssertExpectedLoggingEvent(loggingEvent, loggingEventData);
 
@@ -145,7 +145,7 @@ public class FixingTest
       Level = Level.Warn,
       Message = "Logging event works",
       Domain = "ReallySimpleApp",
-      LocationInfo = new LocationInfo(typeof(FixingTest).Name, "Main", "Class1.cs", "29"), //Completely arbitary
+      LocationInfo = new(nameof(FixingTest), "Main", "Class1.cs", "29"), //Completely arbitary
       ThreadName = Thread.CurrentThread.Name,
       TimeStampUtc = DateTime.UtcNow.Date,
       ExceptionString = "Exception occured here",
@@ -161,7 +161,7 @@ public class FixingTest
     Assert.That(loggingEventData.Identity, Is.Null, "Identity is incorrect");
     Assert.That(loggingEventData.Level, Is.EqualTo(Level.Warn), "Level is incorrect");
     Assert.That(loggingEvent.LocationInformation, Is.Not.Null);
-    Assert.That(loggingEvent.LocationInformation!.MethodName, Is.EqualTo("get_LocationInformation"), "Location Info is incorrect");
+    Assert.That(loggingEvent.LocationInformation.MethodName, Is.EqualTo("get_LocationInformation"), "Location Info is incorrect");
     Assert.That(loggingEventData.LoggerName, Is.EqualTo("log4net.Tests.Core.FixingTest"), "LoggerName is incorrect");
     Assert.That(loggingEvent.Repository, Is.EqualTo(LogManager.GetRepository(TestRepository)), "Repository is incorrect");
     Assert.That(loggingEventData.ThreadName, Is.EqualTo(Thread.CurrentThread.Name), "ThreadName is incorrect");

--- a/src/log4net.Tests/Core/LevelMappingTest.cs
+++ b/src/log4net.Tests/Core/LevelMappingTest.cs
@@ -17,7 +17,6 @@
 //
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -80,7 +79,7 @@ public sealed class LevelMappingTest
 
     List<LevelMappingEntry> sorted = (List<LevelMappingEntry>)typeof(LevelMapping)
       .GetMethod("SortEntries", BindingFlags.NonPublic | BindingFlags.Instance)!
-      .Invoke(mapping, Array.Empty<object>())!;
+      .Invoke(mapping, [])!;
 
     Assert.That(sorted, Is.EquivalentTo(withoutDuplicates));
     Assert.That(sorted, Is.Not.EqualTo(withoutDuplicates).AsCollection);

--- a/src/log4net.Tests/Core/LevelTest.cs
+++ b/src/log4net.Tests/Core/LevelTest.cs
@@ -17,7 +17,6 @@
 //
 #endregion
 
-using System;
 using System.Runtime.CompilerServices;
 using log4net.Core;
 

--- a/src/log4net.Tests/Core/LoggingEventTest.cs
+++ b/src/log4net.Tests/Core/LoggingEventTest.cs
@@ -71,10 +71,10 @@ public sealed class LoggingEventTest
     Assert.That(ev2.ThreadName, Is.EqualTo("aThread"));
     Assert.That(ev2.TimeStampUtc, Is.EqualTo(timestamp));
     Assert.That(ev2.LocationInfo, Is.Not.Null);
-    Assert.That(ev2.LocationInfo!.ClassName, Is.EqualTo("System.RuntimeMethodHandle"));
-    Assert.That(ev2.LocationInfo!.MethodName, Is.EqualTo("InvokeMethod"));
-    Assert.That(ev2.LocationInfo!.FileName, Is.Null);
-    Assert.That(ev2.LocationInfo!.LineNumber, Is.EqualTo("0"));
+    Assert.That(ev2.LocationInfo.ClassName, Is.EqualTo("System.RuntimeMethodHandle"));
+    Assert.That(ev2.LocationInfo.MethodName, Is.EqualTo("InvokeMethod"));
+    Assert.That(ev2.LocationInfo.FileName, Is.Null);
+    Assert.That(ev2.LocationInfo.LineNumber, Is.EqualTo("0"));
     Assert.That(ev2.UserName, Is.EqualTo("aUser"));
     Assert.That(ev2.Identity, Is.EqualTo("anIdentity"));
     Assert.That(ev2.ExceptionObject, Is.Null);
@@ -99,16 +99,16 @@ public sealed class LoggingEventTest
     LoggingEvent ev = (LoggingEvent)formatter.Deserialize(stream);
     Assert.That(ev, Is.Not.Null);
 
-    Assert.That(ev!.LoggerName, Is.EqualTo("aLogger"));
+    Assert.That(ev.LoggerName, Is.EqualTo("aLogger"));
     Assert.That(ev.Level, Is.EqualTo(Level.Log4Net_Debug));
     Assert.That(ev.MessageObject, Is.Null);
     Assert.That(ev.RenderedMessage, Is.EqualTo("aMessage"));
     Assert.That(ev.ThreadName, Is.EqualTo("aThread"));
     Assert.That(ev.LocationInfo, Is.Not.Null);
-    Assert.That(ev.LocationInfo!.ClassName, Is.EqualTo("?"));
-    Assert.That(ev.LocationInfo!.MethodName, Is.EqualTo("?"));
-    Assert.That(ev.LocationInfo!.FileName, Is.EqualTo("?"));
-    Assert.That(ev.LocationInfo!.LineNumber, Is.EqualTo("?"));
+    Assert.That(ev.LocationInfo.ClassName, Is.EqualTo("?"));
+    Assert.That(ev.LocationInfo.MethodName, Is.EqualTo("?"));
+    Assert.That(ev.LocationInfo.FileName, Is.EqualTo("?"));
+    Assert.That(ev.LocationInfo.LineNumber, Is.EqualTo("?"));
     Assert.That(ev.UserName, Is.EqualTo("aUser"));
     Assert.That(ev.Identity, Is.EqualTo("anIdentity"));
     Assert.That(ev.ExceptionObject, Is.Null);
@@ -146,10 +146,9 @@ public sealed class LoggingEventTest
   [Test]
   public void UserNameTest()
   {
-    string expectedUserName =
-                Environment.OSVersion.VersionString.StartsWith("Microsoft Windows")?
-                  $"{Environment.UserDomainName}\\{Environment.UserName}"
-                : Environment.UserName;
+    string expectedUserName = Environment.OSVersion.Platform == PlatformID.Win32NT
+      ? @$"{Environment.UserDomainName}\{Environment.UserName}"
+      : Environment.UserName;
     LoggingEvent sut = new();
     Assert.That(sut.UserName, Is.EqualTo(expectedUserName));
   }

--- a/src/log4net.Tests/Filter/FilterTest.cs
+++ b/src/log4net.Tests/Filter/FilterTest.cs
@@ -38,25 +38,26 @@ public class FilterTest
   public void FilterConfigurationTest()
   {
     var log4NetConfig = new XmlDocument();
-    log4NetConfig.LoadXml(@"
-            <log4net>
-            <appender name=""MemoryAppender"" type=""log4net.Appender.MemoryAppender, log4net"">
-                <filter type=""log4net.Tests.Filter.MultiplePropertyFilter, log4net.Tests"">
-                    <condition>
-                        <key value=""ABC"" />
-                        <stringToMatch value=""123"" />
-                    </condition>
-                    <condition>
-                        <key value=""DEF"" />
-                        <stringToMatch value=""456"" />
-                    </condition>
-                </filter>
-            </appender>
-            <root>
-                <level value=""ALL"" />
-                <appender-ref ref=""MemoryAppender"" />
-            </root>
-            </log4net>");
+    log4NetConfig.LoadXml("""
+      <log4net>
+      <appender name="MemoryAppender" type="log4net.Appender.MemoryAppender, log4net">
+          <filter type="log4net.Tests.Filter.MultiplePropertyFilter, log4net.Tests">
+              <condition>
+                  <key value="ABC" />
+                  <stringToMatch value="123" />
+              </condition>
+              <condition>
+                  <key value="DEF" />
+                  <stringToMatch value="456" />
+              </condition>
+          </filter>
+      </appender>
+      <root>
+          <level value="ALL" />
+          <appender-ref ref="MemoryAppender" />
+      </root>
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -70,7 +71,7 @@ public class FilterTest
     MultiplePropertyFilter? multiplePropertyFilter =
         ((AppenderSkeleton)appender!).FilterHead as MultiplePropertyFilter;
     Assert.That(multiplePropertyFilter, Is.Not.Null);
-    MultiplePropertyFilter.Condition[] conditions = multiplePropertyFilter!.GetConditions();
+    MultiplePropertyFilter.Condition[] conditions = multiplePropertyFilter.GetConditions();
     Assert.That(conditions, Has.Length.EqualTo(2));
     Assert.That(conditions[0].Key, Is.EqualTo("ABC"));
     Assert.That(conditions[0].StringToMatch, Is.EqualTo("123"));
@@ -79,9 +80,9 @@ public class FilterTest
   }
 }
 
-public class MultiplePropertyFilter : FilterSkeleton
+internal sealed class MultiplePropertyFilter : FilterSkeleton
 {
-  private readonly List<Condition> _conditions = new();
+  private readonly List<Condition> _conditions = [];
 
   public override FilterDecision Decide(LoggingEvent loggingEvent) => FilterDecision.Accept;
 
@@ -89,7 +90,7 @@ public class MultiplePropertyFilter : FilterSkeleton
 
   public void AddCondition(Condition condition) => _conditions.Add(condition);
 
-  public class Condition
+  internal sealed class Condition
   {
     public string? Key { get; set; }
     public string? StringToMatch { get; set; }

--- a/src/log4net.Tests/Filter/FilterTest.cs
+++ b/src/log4net.Tests/Filter/FilterTest.cs
@@ -38,7 +38,8 @@ public class FilterTest
   public void FilterConfigurationTest()
   {
     var log4NetConfig = new XmlDocument();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
       <appender name="MemoryAppender" type="log4net.Appender.MemoryAppender, log4net">
           <filter type="log4net.Tests.Filter.MultiplePropertyFilter, log4net.Tests">
@@ -57,7 +58,7 @@ public class FilterTest
           <appender-ref ref="MemoryAppender" />
       </root>
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);

--- a/src/log4net.Tests/Hierarchy/HierarchyTest.cs
+++ b/src/log4net.Tests/Hierarchy/HierarchyTest.cs
@@ -37,7 +37,8 @@ public class HierarchyTest
   {
     // LOG4NET-53: Allow repository properties to be set in the config file
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <property>
           <key value="two-plus-two" />
@@ -51,7 +52,7 @@ public class HierarchyTest
           <appender-ref ref="StringAppender" />
         </root>
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -99,7 +100,8 @@ public class HierarchyTest
   public void LoggerNameCanConsistOfASingleDot()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
           <layout type="log4net.Layout.SimpleLayout" />
@@ -112,7 +114,7 @@ public class HierarchyTest
           <level value="WARN" />
         </logger>
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -122,7 +124,8 @@ public class HierarchyTest
   public void LoggerNameCanConsistOfASingleNonDot()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
           <layout type="log4net.Layout.SimpleLayout" />
@@ -135,7 +138,7 @@ public class HierarchyTest
           <level value="WARN" />
         </logger>
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -145,7 +148,8 @@ public class HierarchyTest
   public void LoggerNameCanContainSequenceOfDots()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
           <layout type="log4net.Layout.SimpleLayout" />
@@ -158,7 +162,7 @@ public class HierarchyTest
           <level value="WARN" />
         </logger>
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -172,7 +176,8 @@ public class HierarchyTest
   public void CreateNestedLoggersInReverseOrder()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
           <layout type="log4net.Layout.SimpleLayout" />
@@ -182,7 +187,7 @@ public class HierarchyTest
           <appender-ref ref="StringAppender" />
         </root>
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -198,7 +203,8 @@ public class HierarchyTest
   public void CreateChildLoggersMultiThreaded()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
           <layout type="log4net.Layout.SimpleLayout" />
@@ -208,7 +214,7 @@ public class HierarchyTest
           <appender-ref ref="StringAppender" />
         </root>
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);

--- a/src/log4net.Tests/Hierarchy/HierarchyTest.cs
+++ b/src/log4net.Tests/Hierarchy/HierarchyTest.cs
@@ -37,20 +37,21 @@ public class HierarchyTest
   {
     // LOG4NET-53: Allow repository properties to be set in the config file
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
+    log4NetConfig.LoadXml("""
       <log4net>
         <property>
-          <key value=""two-plus-two"" />
-          <value value=""4"" />
+          <key value="two-plus-two" />
+          <value value="4" />
         </property>
-        <appender name=""StringAppender"" type=""log4net.Tests.Appender.StringAppender, log4net.Tests"">
-          <layout type=""log4net.Layout.SimpleLayout"" />
+        <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
+          <layout type="log4net.Layout.SimpleLayout" />
         </appender>
         <root>
-          <level value=""ALL"" />
-          <appender-ref ref=""StringAppender"" />
+          <level value="ALL" />
+          <appender-ref ref="StringAppender" />
         </root>
-      </log4net>");
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -98,19 +99,20 @@ public class HierarchyTest
   public void LoggerNameCanConsistOfASingleDot()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
+    log4NetConfig.LoadXml("""
       <log4net>
-        <appender name=""StringAppender"" type=""log4net.Tests.Appender.StringAppender, log4net.Tests"">
-          <layout type=""log4net.Layout.SimpleLayout"" />
+        <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
+          <layout type="log4net.Layout.SimpleLayout" />
         </appender>
         <root>
-          <level value=""ALL"" />
-          <appender-ref ref=""StringAppender"" />
+          <level value="ALL" />
+          <appender-ref ref="StringAppender" />
         </root>
-        <logger name=""."">
-          <level value=""WARN"" />
+        <logger name=".">
+          <level value="WARN" />
         </logger>
-      </log4net>");
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -120,19 +122,20 @@ public class HierarchyTest
   public void LoggerNameCanConsistOfASingleNonDot()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
+    log4NetConfig.LoadXml("""
       <log4net>
-        <appender name=""StringAppender"" type=""log4net.Tests.Appender.StringAppender, log4net.Tests"">
-          <layout type=""log4net.Layout.SimpleLayout"" />
+        <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
+          <layout type="log4net.Layout.SimpleLayout" />
         </appender>
         <root>
-          <level value=""ALL"" />
-          <appender-ref ref=""StringAppender"" />
+          <level value="ALL" />
+          <appender-ref ref="StringAppender" />
         </root>
-        <logger name=""L"">
-          <level value=""WARN"" />
+        <logger name="L">
+          <level value="WARN" />
         </logger>
-      </log4net>");
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -142,19 +145,20 @@ public class HierarchyTest
   public void LoggerNameCanContainSequenceOfDots()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
+    log4NetConfig.LoadXml("""
       <log4net>
-        <appender name=""StringAppender"" type=""log4net.Tests.Appender.StringAppender, log4net.Tests"">
-          <layout type=""log4net.Layout.SimpleLayout"" />
+        <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
+          <layout type="log4net.Layout.SimpleLayout" />
         </appender>
         <root>
-          <level value=""ALL"" />
-          <appender-ref ref=""StringAppender"" />
+          <level value="ALL" />
+          <appender-ref ref="StringAppender" />
         </root>
-        <logger name=""L..M"">
-          <level value=""WARN"" />
+        <logger name="L..M">
+          <level value="WARN" />
         </logger>
-      </log4net>");
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -168,16 +172,17 @@ public class HierarchyTest
   public void CreateNestedLoggersInReverseOrder()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
+    log4NetConfig.LoadXml("""
       <log4net>
-        <appender name=""StringAppender"" type=""log4net.Tests.Appender.StringAppender, log4net.Tests"">
-          <layout type=""log4net.Layout.SimpleLayout"" />
+        <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
+          <layout type="log4net.Layout.SimpleLayout" />
         </appender>
         <root>
-          <level value=""ALL"" />
-          <appender-ref ref=""StringAppender"" />
+          <level value="ALL" />
+          <appender-ref ref="StringAppender" />
         </root>
-      </log4net>");
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -193,16 +198,17 @@ public class HierarchyTest
   public void CreateChildLoggersMultiThreaded()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
+    log4NetConfig.LoadXml("""
       <log4net>
-        <appender name=""StringAppender"" type=""log4net.Tests.Appender.StringAppender, log4net.Tests"">
-          <layout type=""log4net.Layout.SimpleLayout"" />
+        <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
+          <layout type="log4net.Layout.SimpleLayout" />
         </appender>
         <root>
-          <level value=""ALL"" />
-          <appender-ref ref=""StringAppender"" />
+          <level value="ALL" />
+          <appender-ref ref="StringAppender" />
         </root>
-      </log4net>");
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);

--- a/src/log4net.Tests/Layout/DynamicPatternLayoutTest.cs
+++ b/src/log4net.Tests/Layout/DynamicPatternLayoutTest.cs
@@ -19,8 +19,6 @@
 
 using log4net.Layout;
 
-using NUnit.Framework;
-
 namespace log4net.Tests.Layout;
 
 /// <summary>

--- a/src/log4net.Tests/LoggerRepository/ConfigurationMessages.cs
+++ b/src/log4net.Tests/LoggerRepository/ConfigurationMessages.cs
@@ -43,7 +43,8 @@ public class ConfigurationMessages
       LogLog.InternalDebugging = true;
 
       XmlDocument log4NetConfig = new();
-      log4NetConfig.LoadXml("""
+      log4NetConfig.LoadXml(
+        """
         <log4net>
           <appender name="LogLogAppender" type="log4net.Tests.LoggerRepository.LogLogAppender, log4net.Tests">
             <layout type="log4net.Layout.SimpleLayout" />
@@ -57,7 +58,7 @@ public class ConfigurationMessages
             <appender-ref ref="MemoryAppender" />
           </root>  
         </log4net>
-      """);
+        """);
 
       ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
       rep.ConfigurationChanged += new LoggerRepositoryConfigurationChangedEventHandler(rep_ConfigurationChanged);

--- a/src/log4net.Tests/LoggerRepository/ConfigurationMessages.cs
+++ b/src/log4net.Tests/LoggerRepository/ConfigurationMessages.cs
@@ -43,20 +43,21 @@ public class ConfigurationMessages
       LogLog.InternalDebugging = true;
 
       XmlDocument log4NetConfig = new();
-      log4NetConfig.LoadXml(@"
-                <log4net>
-                  <appender name=""LogLogAppender"" type=""log4net.Tests.LoggerRepository.LogLogAppender, log4net.Tests"">
-                    <layout type=""log4net.Layout.SimpleLayout"" />
-                  </appender>
-                  <appender name=""MemoryAppender"" type=""log4net.Appender.MemoryAppender"">
-                    <layout type=""log4net.Layout.SimpleLayout"" />
-                  </appender>
-                  <root>
-                    <level value=""ALL"" />
-                    <appender-ref ref=""LogLogAppender"" />
-                    <appender-ref ref=""MemoryAppender"" />
-                  </root>  
-                </log4net>");
+      log4NetConfig.LoadXml("""
+        <log4net>
+          <appender name="LogLogAppender" type="log4net.Tests.LoggerRepository.LogLogAppender, log4net.Tests">
+            <layout type="log4net.Layout.SimpleLayout" />
+          </appender>
+          <appender name="MemoryAppender" type="log4net.Appender.MemoryAppender">
+            <layout type="log4net.Layout.SimpleLayout" />
+          </appender>
+          <root>
+            <level value="ALL" />
+            <appender-ref ref="LogLogAppender" />
+            <appender-ref ref="MemoryAppender" />
+          </root>  
+        </log4net>
+      """);
 
       ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
       rep.ConfigurationChanged += new LoggerRepositoryConfigurationChangedEventHandler(rep_ConfigurationChanged);

--- a/src/log4net.Tests/Signing.cs
+++ b/src/log4net.Tests/Signing.cs
@@ -33,6 +33,6 @@ public class Signing
     // Act
     var result = asm.GetName().GetPublicKey();
     Assert.That(result, Is.Not.Null);
-    Assert.That(result!.Length, Is.Not.EqualTo(0));
+    Assert.That(result, Is.Not.Empty);
   }
 }

--- a/src/log4net.Tests/Util/LogLogTest.cs
+++ b/src/log4net.Tests/Util/LogLogTest.cs
@@ -74,7 +74,7 @@ public class LogLogTest
   [Test]
   public void LogReceivedAdapter()
   {
-    List<LogLog> messages = new();
+    List<LogLog> messages = [];
 
     using LogLog.LogReceivedAdapter _ = new(messages);
     LogLog.Debug(GetType(), "Won't be recorded");

--- a/src/log4net.Tests/Util/PatternConverterTest.cs
+++ b/src/log4net.Tests/Util/PatternConverterTest.cs
@@ -40,7 +40,8 @@ public class PatternConverterTest
   public void PatternLayoutConverterProperties()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
           <layout type="log4net.Layout.PatternLayout">
@@ -64,7 +65,7 @@ public class PatternConverterTest
           <appender-ref ref="StringAppender" />
         </root>  
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -88,7 +89,8 @@ public class PatternConverterTest
   public void PatternConverterProperties()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml("""
+    log4NetConfig.LoadXml(
+      """
       <log4net>
         <appender name="PatternStringAppender" type="log4net.Tests.Util.PatternStringAppender, log4net.Tests">
           <layout type="log4net.Layout.SimpleLayout" />
@@ -113,7 +115,7 @@ public class PatternConverterTest
           <appender-ref ref="PatternStringAppender" />
         </root>  
       </log4net>
-    """);
+      """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);

--- a/src/log4net.Tests/Util/PatternConverterTest.cs
+++ b/src/log4net.Tests/Util/PatternConverterTest.cs
@@ -20,6 +20,7 @@
 */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Xml;
 using log4net.Config;
@@ -39,30 +40,31 @@ public class PatternConverterTest
   public void PatternLayoutConverterProperties()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
-                <log4net>
-                  <appender name=""StringAppender"" type=""log4net.Tests.Appender.StringAppender, log4net.Tests"">
-                    <layout type=""log4net.Layout.PatternLayout"">
-                        <converter>
-                            <name value=""propertyKeyCount"" />
-                            <type value=""log4net.Tests.Util.PropertyKeyCountPatternLayoutConverter, log4net.Tests"" />
-                            <property>
-                                <key value=""one-plus-one"" />
-                                <value value=""2"" />
-                            </property>
-                            <property>
-                               <key value=""two-plus-two"" />
-                               <value value=""4"" />
-                            </property> 
-                        </converter>
-                        <conversionPattern value=""%propertyKeyCount"" />
-                    </layout>
-                  </appender>
-                  <root>
-                    <level value=""ALL"" />                  
-                    <appender-ref ref=""StringAppender"" />
-                  </root>  
-                </log4net>");
+    log4NetConfig.LoadXml("""
+      <log4net>
+        <appender name="StringAppender" type="log4net.Tests.Appender.StringAppender, log4net.Tests">
+          <layout type="log4net.Layout.PatternLayout">
+              <converter>
+                  <name value="propertyKeyCount" />
+                  <type value="log4net.Tests.Util.PropertyKeyCountPatternLayoutConverter, log4net.Tests" />
+                  <property>
+                      <key value="one-plus-one" />
+                      <value value="2" />
+                  </property>
+                  <property>
+                     <key value="two-plus-two" />
+                     <value value="4" />
+                  </property> 
+              </converter>
+              <conversionPattern value="%propertyKeyCount" />
+          </layout>
+        </appender>
+        <root>
+          <level value="ALL" />                  
+          <appender-ref ref="StringAppender" />
+        </root>  
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -73,8 +75,8 @@ public class PatternConverterTest
     PropertyKeyCountPatternLayoutConverter? converter =
         PropertyKeyCountPatternLayoutConverter.MostRecentInstance;
     Assert.That(converter, Is.Not.Null);
-    Assert.That(converter!.Properties, Is.Not.Null);
-    Assert.That(converter.Properties!, Has.Count.EqualTo(2));
+    Assert.That(converter.Properties, Is.Not.Null);
+    Assert.That(converter.Properties, Has.Count.EqualTo(2));
     Assert.That(converter.Properties["two-plus-two"], Is.EqualTo("4"));
 
     StringAppender appender =
@@ -86,31 +88,32 @@ public class PatternConverterTest
   public void PatternConverterProperties()
   {
     XmlDocument log4NetConfig = new();
-    log4NetConfig.LoadXml(@"
-                <log4net>
-                  <appender name=""PatternStringAppender"" type=""log4net.Tests.Util.PatternStringAppender, log4net.Tests"">
-                    <layout type=""log4net.Layout.SimpleLayout"" />
-                    <setting>
-                        <converter>
-                            <name value=""propertyKeyCount"" />
-                            <type value=""log4net.Tests.Util.PropertyKeyCountPatternConverter, log4net.Tests"" />
-                            <property>
-                                <key value=""one-plus-one"" />
-                                <value value=""2"" />
-                            </property>
-                            <property>
-                               <key value=""two-plus-two"" />
-                               <value value=""4"" />
-                            </property> 
-                        </converter>
-                        <conversionPattern value=""%propertyKeyCount"" />
-                    </setting>
-                  </appender>
-                  <root>
-                    <level value=""ALL"" />                  
-                    <appender-ref ref=""PatternStringAppender"" />
-                  </root>  
-                </log4net>");
+    log4NetConfig.LoadXml("""
+      <log4net>
+        <appender name="PatternStringAppender" type="log4net.Tests.Util.PatternStringAppender, log4net.Tests">
+          <layout type="log4net.Layout.SimpleLayout" />
+          <setting>
+              <converter>
+                  <name value="propertyKeyCount" />
+                  <type value="log4net.Tests.Util.PropertyKeyCountPatternConverter, log4net.Tests" />
+                  <property>
+                      <key value="one-plus-one" />
+                      <value value="2" />
+                  </property>
+                  <property>
+                     <key value="two-plus-two" />
+                     <value value="4" />
+                  </property> 
+              </converter>
+              <conversionPattern value="%propertyKeyCount" />
+          </setting>
+        </appender>
+        <root>
+          <level value="ALL" />                  
+          <appender-ref ref="PatternStringAppender" />
+        </root>  
+      </log4net>
+    """);
 
     ILoggerRepository rep = LogManager.CreateRepository(Guid.NewGuid().ToString());
     XmlConfigurator.Configure(rep, log4NetConfig["log4net"]!);
@@ -121,44 +124,49 @@ public class PatternConverterTest
     PropertyKeyCountPatternConverter? converter =
         PropertyKeyCountPatternConverter.MostRecentInstance;
     Assert.That(converter, Is.Not.Null);
-    Assert.That(converter!.Properties, Is.Not.Null);
-    Assert.That(converter!.Properties!, Has.Count.EqualTo(2));
+    Assert.That(converter.Properties, Is.Not.Null);
+    Assert.That(converter.Properties, Has.Count.EqualTo(2));
     Assert.That(converter.Properties["two-plus-two"], Is.EqualTo("4"));
 
     PatternStringAppender appender =
         (PatternStringAppender)LogManager.GetRepository(rep.Name).GetAppenders()[0];
     Assert.That(appender.Setting, Is.Not.Null);
-    Assert.That(appender.Setting!.Format(), Is.EqualTo("2"));
+    Assert.That(appender.Setting.Format(), Is.EqualTo("2"));
   }
 }
 
+// ReSharper disable once ClassNeverInstantiated.Global
 public class PropertyKeyCountPatternLayoutConverter : PatternLayoutConverter
 {
   public PropertyKeyCountPatternLayoutConverter() => MostRecentInstance = this;
 
-  [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
+  [SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
   protected override void Convert(TextWriter writer, LoggingEvent loggingEvent) 
     => writer.Write(Properties!.GetKeys().Length);
 
   public static PropertyKeyCountPatternLayoutConverter? MostRecentInstance { get; private set; }
 }
 
+// ReSharper disable once ClassNeverInstantiated.Global
 public class PropertyKeyCountPatternConverter : PatternConverter
 {
   public PropertyKeyCountPatternConverter() => MostRecentInstance = this;
 
-  [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
+  [SuppressMessage("Design", "CA1062:Validate arguments of public methods")]
   public override void Convert(TextWriter writer, object? state)
     => writer.Write(Properties!.GetKeys().Length);
 
   public static PropertyKeyCountPatternConverter? MostRecentInstance { get; private set; }
 }
 
-public class PatternStringAppender : StringAppender
+// ReSharper disable once ClassNeverInstantiated.Global
+internal sealed class PatternStringAppender : StringAppender
 {
-  public PatternStringAppender() => MostRecentInstace = this;
+  public PatternStringAppender() => MostRecentInstance = this;
 
+  // ReSharper disable once UnusedAutoPropertyAccessor.Global
   public PatternString? Setting { get; set; }
 
-  public static PatternStringAppender? MostRecentInstace { get; private set; }
+  // ReSharper disable once UnusedAutoPropertyAccessor.Global
+  public static PatternStringAppender? MostRecentInstance { get; private set; }
 }

--- a/src/log4net.Tests/Util/PatternStringTest.cs
+++ b/src/log4net.Tests/Util/PatternStringTest.cs
@@ -56,13 +56,14 @@ public class PatternStringTest : MarshalByRefObject
   [Test]
   public void TestAppSettingPathConverter()
   {
-    string configurationFileContent = """
+    const string configurationFileContent = 
+      """
       <configuration>
         <appSettings>
           <add key="TestKey" value = "TestValue" />
         </appSettings>
       </configuration>
-    """;
+      """;
     string? configurationFileName = null;
     AppDomain? appDomain = null;
     try
@@ -93,13 +94,16 @@ public class PatternStringTest : MarshalByRefObject
     PatternString patternString = new(pattern);
     string evaluatedPattern = patternString.Format();
     string appSettingValue = ConfigurationManager.AppSettings["TestKey"];
-    Assert.That(appSettingValue, Is.EqualTo("TestValue"), "Expected configuration file to contain a key TestKey with the value TestValue");
-    Assert.That(evaluatedPattern, Is.EqualTo(appSettingValue), "Evaluated pattern expected to be identical to appSetting value");
+    Assert.That(appSettingValue, Is.EqualTo("TestValue"), 
+      "Expected configuration file to contain a key TestKey with the value TestValue");
+    Assert.That(evaluatedPattern, Is.EqualTo(appSettingValue), 
+      "Evaluated pattern expected to be identical to appSetting value");
 
     string badPattern = "%appSetting{UnknownKey}";
     patternString = new PatternString(badPattern);
     evaluatedPattern = patternString.Format();
-    Assert.That(evaluatedPattern, Is.EqualTo("(null)"), "Evaluated pattern expected to be \"(null)\" for non-existent appSettings key");
+    Assert.That(evaluatedPattern, Is.EqualTo("(null)"), 
+      "Evaluated pattern expected to be \"(null)\" for non-existent appSettings key");
   }
 
   private static string CreateTempConfigFile(string configurationFileContent)
@@ -116,8 +120,7 @@ public class PatternStringTest : MarshalByRefObject
       ApplicationBase = AppDomain.CurrentDomain.BaseDirectory,
       ConfigurationFile = configurationFileName
     };
-    AppDomain ad = AppDomain.CreateDomain(domainName, null, ads);
-    return ad;
+    return AppDomain.CreateDomain(domainName, null, ads);
   }
 }
 #endif

--- a/src/log4net.Tests/Util/PatternStringTest.cs
+++ b/src/log4net.Tests/Util/PatternStringTest.cs
@@ -56,13 +56,13 @@ public class PatternStringTest : MarshalByRefObject
   [Test]
   public void TestAppSettingPathConverter()
   {
-    string configurationFileContent = @"
-<configuration>
-  <appSettings>
-    <add key=""TestKey"" value = ""TestValue"" />
-  </appSettings>
-</configuration>
-";
+    string configurationFileContent = """
+      <configuration>
+        <appSettings>
+          <add key="TestKey" value = "TestValue" />
+        </appSettings>
+      </configuration>
+    """;
     string? configurationFileName = null;
     AppDomain? appDomain = null;
     try

--- a/src/log4net.Tests/Util/SystemInfoTest.cs
+++ b/src/log4net.Tests/Util/SystemInfoTest.cs
@@ -55,9 +55,9 @@ public class SystemInfoTest
 
   private static Func<string> GetAssemblyLocationInfoMethodCall()
   {
-    var method = typeof(SystemInfoTest).GetMethod(nameof(TestAssemblyLocationInfoMethod), Array.Empty<Type>());
-    var methodCall = Expression.Call(null, method!, Array.Empty<Expression>());
-    return Expression.Lambda<Func<string>>(methodCall, Array.Empty<ParameterExpression>()).Compile();
+    var method = typeof(SystemInfoTest).GetMethod(nameof(TestAssemblyLocationInfoMethod), []);
+    var methodCall = Expression.Call(null, method!, []);
+    return Expression.Lambda<Func<string>>(methodCall, []).Compile();
   }
 
   [System.Diagnostics.CodeAnalysis.SuppressMessage("Structure", "NUnit1028:The non-test method is public",
@@ -68,9 +68,7 @@ public class SystemInfoTest
   [Test]
   public void TestGetTypeFromStringFullyQualified()
   {
-    Type? t;
-
-    t = GetTypeFromString("log4net.Tests.Util.SystemInfoTest,log4net.Tests", false, false);
+    Type? t = GetTypeFromString("log4net.Tests.Util.SystemInfoTest,log4net.Tests", false, false);
     Assert.That(t, Is.SameAs(typeof(SystemInfoTest)), "Test explicit case sensitive type load");
 
     t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST,log4net.Tests", false, true);
@@ -84,9 +82,7 @@ public class SystemInfoTest
   [Platform(Include = "Win")]
   public void TestGetTypeFromStringCaseInsensitiveOnAssemblyName()
   {
-    Type? t;
-
-    t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST,LOG4NET.TESTS", false, true);
+    Type? t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST,LOG4NET.TESTS", false, true);
     Assert.That(t, Is.SameAs(typeof(SystemInfoTest)), "Test explicit case in-sensitive type load caps");
 
     t = GetTypeFromString("log4net.tests.util.systeminfotest,log4net.tests", false, true);
@@ -96,9 +92,7 @@ public class SystemInfoTest
   [Test]
   public void TestGetTypeFromStringRelative()
   {
-    Type? t;
-
-    t = GetTypeFromString("log4net.Tests.Util.SystemInfoTest", false, false);
+    Type? t = GetTypeFromString("log4net.Tests.Util.SystemInfoTest", false, false);
     Assert.That(t, Is.SameAs(typeof(SystemInfoTest)), "Test explicit case sensitive type load");
 
     t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST", false, true);
@@ -111,9 +105,7 @@ public class SystemInfoTest
   [Test]
   public void TestGetTypeFromStringSearch()
   {
-    Type? t;
-
-    t = GetTypeFromString("log4net.Util.SystemInfo", false, false);
+    Type? t = GetTypeFromString("log4net.Util.SystemInfo", false, false);
     Assert.That(t, Is.SameAs(typeof(SystemInfo)),
                                      string.Format("Test explicit case sensitive type load found {0} rather than {1}",
                                                    t?.AssemblyQualifiedName, typeof(SystemInfo).AssemblyQualifiedName));
@@ -128,9 +120,7 @@ public class SystemInfoTest
   [Test]
   public void TestGetTypeFromStringFails1()
   {
-    Type? t;
-
-    t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST,LOG4NET.TESTS", false, false);
+    Type? t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST,LOG4NET.TESTS", false, false);
     Assert.That(t, Is.Null, "Test explicit case sensitive fails type load");
 
     Assert.That(() => GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST,LOG4NET.TESTS", true, false),
@@ -140,9 +130,7 @@ public class SystemInfoTest
   [Test]
   public void TestGetTypeFromStringFails2()
   {
-    Type? t;
-
-    t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST", false, false);
+    Type? t = GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST", false, false);
     Assert.That(t, Is.Null, "Test explicit case sensitive fails type load");
 
     Assert.That(() => GetTypeFromString("LOG4NET.TESTS.UTIL.SYSTEMINFOTEST", true, false),

--- a/src/log4net.Tests/Util/TransformTest.cs
+++ b/src/log4net.Tests/Util/TransformTest.cs
@@ -17,8 +17,6 @@
 //
 #endregion
 
-using System;
-
 using log4net.Util;
 
 using NUnit.Framework;
@@ -32,14 +30,14 @@ public class TransformTest
   [Test]
   public void MaskXmlInvalidCharactersAllowsJapaneseCharacters()
   {
-    string kome = "\u203B";
+    const string kome = "\u203B";
     Assert.That(Transform.MaskXmlInvalidCharacters(kome, "?"), Is.EqualTo(kome));
   }
 
   [Test]
   public void MaskXmlInvalidCharactersMasks0Char()
   {
-    string c = "\u0000";
+    const string c = "\0";
     Assert.That(Transform.MaskXmlInvalidCharacters(c, "?"), Is.EqualTo("?"));
   }
 }

--- a/src/log4net.Tests/log4net.Tests.csproj
+++ b/src/log4net.Tests/log4net.Tests.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\log4net\Diagnostics\CodeAnalysis\CallerArgumentExpressionAttribute.cs" Link="Diagnostics\CodeAnalysis\CallerArgumentExpressionAttribute.cs" />
+    <Compile Include="..\log4net\Diagnostics\CodeAnalysis\IsExternalInit.cs" Link="Diagnostics\CodeAnalysis\IsExternalInit.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\log4net\log4net.csproj" />


### PR DESCRIPTION
- use raw strings for config files in unit tests
- fixed more warnings