### PR TITLE
Keep old, working ubuntu image version.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ macos-latest, ubuntu-22.04, windows-latest ]
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1


### PR DESCRIPTION
Our Ubuntu build fails on the new ubuntu-24.04 image. This change forces use of the old image to keep us green while we adjust to the new image.