### PR TITLE
Make copy of appender list when removing all, for increased thread-safety

### DIFF
--- a/src/log4net/Util/AppenderAttachedImpl.cs
+++ b/src/log4net/Util/AppenderAttachedImpl.cs
@@ -246,7 +246,7 @@ public class AppenderAttachedImpl : IAppenderAttachable
   {
     if (_appenderList is not null)
     {
-      foreach (IAppender appender in _appenderList)
+      foreach (IAppender appender in _appenderList.ToArray())
       {
         try
         {

--- a/src/log4net/Util/AppenderAttachedImpl.cs
+++ b/src/log4net/Util/AppenderAttachedImpl.cs
@@ -71,9 +71,7 @@ public class AppenderAttachedImpl : IAppenderAttachable
       return 0;
     }
 
-    _appenderArray ??= _appenderList.ToArray();
-
-    foreach (IAppender appender in _appenderArray)
+    foreach (IAppender appender in _appenderList.ToArray())
     {
       try
       {
@@ -116,9 +114,7 @@ public class AppenderAttachedImpl : IAppenderAttachable
       return 0;
     }
 
-    _appenderArray ??= _appenderList.ToArray();
-
-    foreach (IAppender appender in _appenderArray)
+    foreach (IAppender appender in _appenderList.ToArray())
     {
       try
       {
@@ -173,7 +169,6 @@ public class AppenderAttachedImpl : IAppenderAttachable
   public void AddAppender(IAppender appender)
   {
     appender.EnsureNotNull();
-    _appenderArray = null;
     _appenderList ??= new(1);
     if (!_appenderList.Contains(appender))
     {
@@ -258,7 +253,6 @@ public class AppenderAttachedImpl : IAppenderAttachable
         }
       }
       _appenderList = null;
-      _appenderArray = null;
     }
   }
 
@@ -283,7 +277,6 @@ public class AppenderAttachedImpl : IAppenderAttachable
       {
         _appenderList = null;
       }
-      _appenderArray = null;
     }
     return appender;
   }
@@ -306,11 +299,6 @@ public class AppenderAttachedImpl : IAppenderAttachable
   /// List of appenders
   /// </summary>
   private AppenderCollection? _appenderList;
-
-  /// <summary>
-  /// Array of appenders, used to cache the appenderList
-  /// </summary>
-  private IAppender[]? _appenderArray;
 
   /// <summary>
   /// The fully qualified type of the AppenderAttachedImpl class.

--- a/src/log4net/Util/AppenderAttachedImpl.cs
+++ b/src/log4net/Util/AppenderAttachedImpl.cs
@@ -218,7 +218,7 @@ public class AppenderAttachedImpl : IAppenderAttachable
   {
     if (_appenderList is not null && name is not null)
     {
-      foreach (IAppender appender in _appenderList)
+      foreach (IAppender appender in _appenderList.ToArray())
       {
         if (name == appender.Name)
         {


### PR DESCRIPTION
Hello,

We have been witnessing this error now and again while using log4net 2.0.15:

```
Collection was modified; enumeration operation may not execute.
   at log4net.Appender.AppenderCollection.Enumerator.MoveNext()
   at log4net.Util.AppenderAttachedImpl.RemoveAllAppenders()
   at log4net.Repository.Hierarchy.Logger.RemoveAllAppenders()
   at log4net.Repository.Hierarchy.Hierarchy.Shutdown()
   at log4net.Core.LoggerManager.Shutdown()
   at log4net.LogManager.Shutdown()
   ```
It looks like the code on master is still susceptible to this, what do you think of this change? (The try-catch should be wel-equipped to handle appenders that have left the List, so long as we can still access their name for the error message...)

Thanks,
Tom