### PR TITLE
Fix: instantiate locking model when it does not exist yet in OpenFile

### DIFF
--- a/src/log4net/Appender/FileAppender.cs
+++ b/src/log4net/Appender/FileAppender.cs
@@ -1542,8 +1542,13 @@ namespace log4net.Appender
         m_fileName = fileName;
         m_appendToFile = append;
 
-        LockingModel.CurrentAppender = this;
-        LockingModel.OpenFile(fileName, append, m_encoding);
+        if (m_lockingModel == null)
+        {
+          m_lockingModel = (LockingModelBase)Activator.CreateInstance(defaultLockingModelType);
+        }
+
+        m_lockingModel.CurrentAppender = this;
+        m_lockingModel.OpenFile(fileName, append, m_encoding);
         m_stream = new LockingStream(LockingModel);
 
         if (m_stream != null)


### PR DESCRIPTION
This is just a draft of an idea for how we could address #223