### PR TITLE
Handle logs with positive CountDirection, extension preservation and placed in dir

### DIFF
--- a/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
+++ b/src/log4net.Tests/Appender/RollingFileAppenderTest.cs
@@ -40,9 +40,9 @@ namespace log4net.Tests.Appender;
 /// Used for internal unit testing the <see cref="RollingFileAppender"/> class.
 /// </summary>
 [TestFixture]
-public sealed class RollingFileAppenderTest
+public class RollingFileAppenderTest
 {
-  private const string FileName = "test_41d3d834_4320f4da.log";
+  protected string FileName = "test_41d3d834_4320f4da.log";
 
   private const string TestMessage98Chars =
     "01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567";
@@ -99,7 +99,7 @@ public sealed class RollingFileAppenderTest
   /// with all appenders, and deletes any test files used
   /// for logging.
   /// </summary>
-  private static void ResetAndDeleteTestFiles()
+  private void ResetAndDeleteTestFiles()
   {
     // Regular users should not use the clear method lightly!
     LogManager.GetRepository().ResetConfiguration();
@@ -144,7 +144,7 @@ public sealed class RollingFileAppenderTest
   /// Finds the number of files that match the base file name,
   /// and matches the result against an expected count
   /// </summary>
-  private static void VerifyFileCount(int expectedCount, bool preserveLogFileNameExtension = false)
+  private void VerifyFileCount(int expectedCount, bool preserveLogFileNameExtension = false)
   {
     List<string> files = GetExistingFiles(FileName, preserveLogFileNameExtension);
     Assert.That(files, Is.Not.Null);
@@ -154,7 +154,7 @@ public sealed class RollingFileAppenderTest
   /// <summary>
   /// Creates a file with the given number, and the shared base file name
   /// </summary>
-  private static void CreateFile(int fileNumber)
+  private void CreateFile(int fileNumber)
   {
     FileInfo fileInfo = new(MakeFileName(FileName, fileNumber));
 
@@ -240,7 +240,7 @@ public sealed class RollingFileAppenderTest
   /// <summary>
   /// Removes all test files that exist
   /// </summary>
-  private static void DeleteTestFiles()
+  private void DeleteTestFiles()
   {
     List<string> files = GetExistingFiles(FileName);
     files.AddRange(GetExistingFiles(FileName, true));
@@ -469,7 +469,7 @@ public sealed class RollingFileAppenderTest
   /// Current file name is always the base file name when counting. Dates will need a different approach.
   /// </summary>
   /// <returns></returns>
-  private static string GetCurrentFile() => FileName;
+  private string GetCurrentFile() => FileName;
 
   /// <summary>
   /// Turns a group of file names into an array of file entries that include the name
@@ -604,7 +604,7 @@ public sealed class RollingFileAppenderTest
   /// <param name="rollingStats"></param>
   /// <param name="currentNext"></param>
   /// <returns></returns>
-  private static RollFileEntry MoveNextEntry(RollingStats rollingStats, RollFileEntry currentNext)
+  private RollFileEntry MoveNextEntry(RollingStats rollingStats, RollFileEntry currentNext)
   {
     rollingStats.MessagesThisFile++;
     if (rollingStats.MessagesThisFile >= rollingStats.MessagesPerFile)
@@ -621,7 +621,7 @@ public sealed class RollingFileAppenderTest
   /// Callback point for the regular expression parser.  Turns
   /// the number into a file name.
   /// </summary>
-  private static string NumberedNameMaker(Match match) 
+  private string NumberedNameMaker(Match match) 
     => MakeFileName(FileName, int.Parse(match.Value));
 
   /// <summary>
@@ -642,7 +642,7 @@ public sealed class RollingFileAppenderTest
   /// that results after each message is logged</param>
   /// <param name="messagesToLog">How many times the test message will be repeatedly logged</param>
   /// <returns></returns>
-  private static RollConditions[] MakeNumericTestEntries(
+  private RollConditions[] MakeNumericTestEntries(
     string testMessage, 
     string backupInfo,
     int messagesToLog)
@@ -660,7 +660,7 @@ public sealed class RollingFileAppenderTest
   /// <param name="messagesToLog">How many times the test message will be repeatedly logged</param>
   /// <param name="evaluator">Function that can turn a number into a filename</param>
   /// <returns></returns>
-  private static RollConditions[] MakeTestEntries(
+  private RollConditions[] MakeTestEntries(
     string testMessage,
     string backupInfo,
     int messagesToLog,
@@ -1592,7 +1592,7 @@ public sealed class RollingFileAppenderTest
   /// 
   /// </summary>
   /// <param name="fileNumbers">Comma separated list of numbers for counted file names</param>
-  private static List<string> MakeTestDataFromString(string fileNumbers)
+  private List<string> MakeTestDataFromString(string fileNumbers)
     => MakeTestDataFromString(FileName, fileNumbers);
 
   /// <summary>

--- a/src/log4net.Tests/Appender/RollingFileAppenderWithDirTest.cs
+++ b/src/log4net.Tests/Appender/RollingFileAppenderWithDirTest.cs
@@ -1,0 +1,33 @@
+﻿#region Apache License
+
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more 
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership. 
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with 
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#endregion
+
+using System.IO;
+using NUnit.Framework;
+
+namespace log4net.Tests.Appender;
+
+[TestFixture]
+public class RollingFileAppenderWithDirTest : RollingFileAppenderTest {
+  public RollingFileAppenderWithDirTest()
+  {
+    base.FileName = Path.Combine(@".\dir\", base.FileName);
+  }
+}

--- a/src/log4net/Appender/RollingFileAppender.cs
+++ b/src/log4net/Appender/RollingFileAppender.cs
@@ -1171,8 +1171,11 @@ public partial class RollingFileAppender : FileAppender
   /// </remarks>
   protected void DeleteFile(string fileName)
   {
+    LogLog.Debug(_declaringType, $"Trying to delete [{fileName}]");
+
     if (!FileExists(fileName))
     {
+      LogLog.Debug(_declaringType, $"[{fileName}] does not exist");
       return;
     }
     // We may not have permission to delete the file, or the file may be locked
@@ -1346,7 +1349,7 @@ public partial class RollingFileAppender : FileAppender
           if (PreserveLogFileNameExtension)
           {
             string extension = Path.GetExtension(archiveFileBaseName);
-            string baseName = Path.GetFileNameWithoutExtension(archiveFileBaseName);
+            string baseName = Path.Combine(Path.GetDirectoryName(archiveFileBaseName), Path.GetFileNameWithoutExtension(archiveFileBaseName));
             int lastDotIndex = baseName.LastIndexOf(".", StringComparison.Ordinal);
             if (lastDotIndex >= 0)
             {

--- a/src/log4net/Appender/RollingFileAppender.cs
+++ b/src/log4net/Appender/RollingFileAppender.cs
@@ -813,7 +813,8 @@ public partial class RollingFileAppender : FileAppender
       string suffix = PreserveLogFileNameExtension
         ? Path.GetExtension(baseFile).ToLowerInvariant()
         : "";
-      if (!curFileName.StartsWith(prefix) || !curFileName.EndsWith(suffix))
+      var curFileNameWithoutDir = Path.GetFileName(curFileName);
+      if (!curFileNameWithoutDir.StartsWith(prefix) || !curFileNameWithoutDir.EndsWith(suffix))
       {
         LogLog.Debug(_declaringType, $"Ignoring file [{curFileName}] because it is from a different date period");
         return;

--- a/src/log4net/Appender/RollingFileAppender.cs
+++ b/src/log4net/Appender/RollingFileAppender.cs
@@ -681,6 +681,7 @@ public partial class RollingFileAppender : FileAppender
     using (SecurityContext?.Impersonate(this))
     {
       string fullPath = Path.GetFullPath(baseFilePath);
+      string dir = Path.GetDirectoryName(baseFilePath);
 
       directory = Path.GetDirectoryName(fullPath);
       if (Directory.Exists(directory))
@@ -690,7 +691,8 @@ public partial class RollingFileAppender : FileAppender
         string[] files = Directory.GetFiles(directory, GetWildcardPatternForFile(baseFileName));
         result.AddRange(files
           .Select(Path.GetFileName)
-          .Where(curFileName => curFileName.StartsWith(Path.GetFileNameWithoutExtension(baseFileName))));
+          .Where(curFileName => curFileName.StartsWith(Path.GetFileNameWithoutExtension(baseFileName)))
+          .Select(file => Path.Combine(dir, file)));
       }
     }
     LogLog.Debug(_declaringType, "Searched for existing files in [" + directory + "]");
@@ -789,7 +791,9 @@ public partial class RollingFileAppender : FileAppender
   {
     curFileName = curFileName.ToLowerInvariant();
     baseFile = baseFile.ToLowerInvariant();
-    if (curFileName.StartsWith(Path.GetFileNameWithoutExtension(baseFile)) == false)
+    var baseFileWithoutExtension = Path.Combine(Path.GetDirectoryName(baseFile), Path.GetFileNameWithoutExtension(baseFile));
+    
+    if (curFileName.StartsWith(baseFileWithoutExtension) == false)
     {
       return; // This is not a log file, so ignore
     }

--- a/src/log4net/Appender/RollingFileAppender.cs
+++ b/src/log4net/Appender/RollingFileAppender.cs
@@ -791,7 +791,7 @@ public partial class RollingFileAppender : FileAppender
   {
     curFileName = curFileName.ToLowerInvariant();
     baseFile = baseFile.ToLowerInvariant();
-    var baseFileWithoutExtension = Path.Combine(Path.GetDirectoryName(baseFile), Path.GetFileNameWithoutExtension(baseFile));
+    var baseFileWithoutExtension = Path.Combine(Path.GetDirectoryName(baseFile) ?? "", Path.GetFileNameWithoutExtension(baseFile));
     
     if (curFileName.StartsWith(baseFileWithoutExtension) == false)
     {


### PR DESCRIPTION
Fix #231 

## Problem
`PreserveLogFileNameExtension` was cutting off the directory part that could be present on config's `File` option. It resulted in unbound rolling of files in the scenario described in the linked issue.

## Solution
Fix the issue by making the `PreserveLogFileNameExtension` code branch handle the directory correctly.

## Testing
It can be tested with the configuration provided in linked issue.