### PR TITLE
Add "Sponsor" buttons to repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##
+# This file controls the "Sponsor" button in this repo.
+# For details see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+#
+# This list includes in the same order, committers of Log4net listed on:
+# https://logging.apache.org/support.html#sponsors
+github:
+  - FreeAndNil


### PR DESCRIPTION
This adds sponsors buttons to this repository as [documented by GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository).

The list is based on the [list of committers accepting GitHub Sponsorship](https://logging.apache.org/support.html#sponsorship-github) intersected with the [official list of active `Log4net` members](https://logging.apache.org/team-list.html). It is related to apache/logging-log4j2#3580