### PR TITLE
Shutdown: Unsubscribe from AppDomain event handlers

### DIFF
--- a/src/log4net/Core/LoggerManager.cs
+++ b/src/log4net/Core/LoggerManager.cs
@@ -344,7 +344,7 @@ public static class LoggerManager
     AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
     
     foreach (ILoggerRepository repository in GetAllRepositories())
-    {      
+    {
       repository.Shutdown();
     }
   }

--- a/src/log4net/Core/LoggerManager.cs
+++ b/src/log4net/Core/LoggerManager.cs
@@ -339,12 +339,12 @@ public static class LoggerManager
   /// </remarks>
   public static void Shutdown()
   {
+    //Cleanup event handlers since they only call this mathod anyways
+    AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
+    AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
+    
     foreach (ILoggerRepository repository in GetAllRepositories())
-    {
-      //Cleanup event handlers since they only call this mathod anyways
-      AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
-      AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
-      
+    {      
       repository.Shutdown();
     }
   }

--- a/src/log4net/Core/LoggerManager.cs
+++ b/src/log4net/Core/LoggerManager.cs
@@ -341,6 +341,10 @@ public static class LoggerManager
   {
     foreach (ILoggerRepository repository in GetAllRepositories())
     {
+      //Cleanup event handlers since they only call this mathod anyways
+      AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+      AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
+      
       repository.Shutdown();
     }
   }

--- a/src/log4net/Core/LoggerManager.cs
+++ b/src/log4net/Core/LoggerManager.cs
@@ -342,8 +342,8 @@ public static class LoggerManager
     foreach (ILoggerRepository repository in GetAllRepositories())
     {
       //Cleanup event handlers since they only call this mathod anyways
-      AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
-      AppDomain.CurrentDomain.DomainUnload += OnDomainUnload;
+      AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
+      AppDomain.CurrentDomain.DomainUnload -= OnDomainUnload;
       
       repository.Shutdown();
     }


### PR DESCRIPTION
When log4net is used in an AssemblyLoadContext that should be unloaded, log4net blocks the unloading since it subscribed to event handlers from the default load context. This PR aims to cleanup the 2 subscriptions that most likely cause this behaviour.

Related discussion here: https://github.com/dotnet/runtime/issues/116142 also contains a working demo of the problem.

Note that I did not fully test the solution yet. But this cleanup is a good measure in any case.