### PR TITLE
shorten console output for unit tests

### DIFF
--- a/src/changelog/3.2.1/268-shorten-test-output.xml
+++ b/src/changelog/3.2.1/268-shorten-test-output.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="268" link="https://github.com/apache/logging-log4net/pull/268"/>
+  <description format="asciidoc">
+    shorten console output for unit tests (by @FreeAndNil in https://github.com/apache/logging-log4net/pull/268[#268])
+  </description>
+</entry>

--- a/src/log4net.Tests/Util/LogLogTest.cs
+++ b/src/log4net.Tests/Util/LogLogTest.cs
@@ -32,6 +32,9 @@ namespace log4net.Tests.Util;
 [TestFixture]
 public class LogLogTest
 {
+  /// <summary>
+  /// Tests the <see cref="TraceListener"/> functionality
+  /// </summary>
   [Test]
   public void TraceListenerCounterTest()
   {
@@ -46,6 +49,9 @@ public class LogLogTest
     Assert.That(listTraceListener.Count, Is.EqualTo(2));
   }
 
+  /// <summary>
+  /// Tests the <see cref="LogLog.EmitInternalMessages"/> property
+  /// </summary>
   [Test]
   public void EmitInternalMessages()
   {
@@ -71,6 +77,9 @@ public class LogLogTest
     }
   }
 
+  /// <summary>
+  /// Tests the <see cref="LogLog.LogReceivedAdapter"/> class.
+  /// </summary>
   [Test]
   public void LogReceivedAdapter()
   {
@@ -90,10 +99,13 @@ public class LogLogTest
   [Test]
   public void LogReceivedAdapterThreading()
   {
-    for (int i = 0; i < 1000; i++)
+    LogLog.ExecuteWithoutEmittingInternalMessages(() =>
     {
-      LogReceivedAdapterThreadingCore(i);
-    }
+      for (int i = 0; i < 1000; i++)
+      {
+        LogReceivedAdapterThreadingCore(i);
+      }
+    });
   }
 
   [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5394:Do not use insecure randomness", 
@@ -119,13 +131,20 @@ public class LogLogTest
   }
 }
 
+/// <summary>
+/// Mock for <see cref="TraceListener"/> that counts the number of calls to <see cref="Write(string?)"/>
+/// </summary>
 internal sealed class TraceListenerCounter : TraceListener
 {
+  /// <inheritdoc/>
   public override void Write(string? message) => Count++;
 
+  /// <inheritdoc/>
   public override void WriteLine(string? message) => Write(message);
 
+  /// <inheritdoc/>
   public void Reset() => Count = 0;
 
+  /// <inheritdoc/>
   public int Count { get; private set; }
 }

--- a/src/log4net/Util/LogLog.cs
+++ b/src/log4net/Util/LogLog.cs
@@ -223,9 +223,28 @@ public sealed class LogLog
   public static bool QuietMode { get; set; }
 
   /// <summary>
-  /// 
+  /// Configures whether internal messages are emitted to Console.Out and Console.Error.
   /// </summary>
   public static bool EmitInternalMessages { get; set; } = true;
+
+  /// <summary>
+  /// Execute the callback with internal messages suppressed
+  /// </summary>
+  /// <param name="callback">Callback</param>
+  public static void ExecuteWithoutEmittingInternalMessages(Action callback)
+  {
+    callback.EnsureNotNull();
+    bool oldEmitInternalMessages = EmitInternalMessages;
+    EmitInternalMessages = false;
+    try
+    {
+      callback();
+    }
+    finally
+    {
+      EmitInternalMessages = oldEmitInternalMessages;
+    }
+  }
 
   /// <summary>
   /// Raises the LogReceived event when an internal messages is received.


### PR DESCRIPTION
The console output in the log4net unit tests was much too long (caused by a single test).