### PR TITLE
Fix DllImport attribute for OutputDebugString function

### DIFF
--- a/src/log4net/Util/NativeMethods.cs
+++ b/src/log4net/Util/NativeMethods.cs
@@ -139,11 +139,7 @@ namespace log4net.Util
     /// Stub for OutputDebugString native method
     /// </summary>
     /// <param name="message">the string to output</param>
-#if NETSTANDARD2_0_OR_GREATER
-    [DllImport("CoreDll.dll")]
-#else
     [DllImport("Kernel32.dll")]
-#endif
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static extern void OutputDebugString(string message);
 


### PR DESCRIPTION
The coredll.dll is clearly a leftover dating back to the NETCF support and WinCE days.
WinCE was the only Windows version where coredll.dll existed. In "normal" Windows the OutputDebugString function is exported by the kernel32.dll according to [Microsoft](https://learn.microsoft.com/en-us/windows/win32/api/debugapi/nf-debugapi-outputdebugstringw)

fixes #269