### PR TITLE
Pin js-yaml to ^4.3.0 via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1141,9 +1141,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
     "@antora/cli": "^3.2.0-rc.2",
     "@antora/site-generator-default": "^3.2.0-rc.2",
     "@asciidoctor/tabs": "^1.0.0-beta.6"
+  },
+  "overrides": {
+    "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
https://github.com/apache/logging-log4net/security/dependabot/80

Antora 3.2.0-rc.2 requires js-yaml ~4.2, which excludes the 4.3.0 release that fixes the merge-key quadratic CPU consumption advisory. No newer Antora is published, so override js-yaml directly. Docs build verified with the overridden version.