### PR TITLE
Prevent content from steering the string match filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,12 @@ almost always be doing.
   the assertion is about control characters, use
   `Contains.Substring(x).Using(StringComparison.Ordinal)`, negated with the `!` operator that
   `Constraint` defines, or assert the whole value with `Is.EqualTo`, which is ordinal.
+- **Give a `[TestCase]` an explicit `TestName` when an argument holds a control character.**
+  Otherwise the whole fixture can become invisible to `dotnet test --filter`, silently: it is
+  listed by `--list-tests` and runs in a full pass, but every filter reports "No test matches".
+  Reproduced with `[TestCase("one", "\x1b[0m")]`; a single argument holding the same escape is
+  fine, so it takes two arguments and an escape character. `AnsiColorTerminalAppenderTest` names
+  all ten of its cases for that reason, and a filtered run there is 54 ms against 9 s for the suite.
 - Mark a test `[NonParallelizable]` when it mutates static state (`LogLog.InternalDebugging`, a
   static field on a test double, a process-wide native registration).
 - Wrap expected internal logging in `LogLog.ExecuteWithoutEmittingInternalMessages(...)` and capture

--- a/src/changelog/3.5.0/313-redact-connection-string-allowlist.xml
+++ b/src/changelog/3.5.0/313-redact-connection-string-allowlist.xml
@@ -8,6 +8,6 @@
     keep secrets out of the `AdoNetAppender` message for a connection it could not open. Hiding
  password-bearing keywords missed `Extended Properties`, which nests a whole connection string, and
  keywords such as `AccessToken` (CWE-532). Only keywords naming the server and account are kept now
- (audit da18b6fd-f028)
+ (audit da18b6fd-f028, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/313-require-powershell-74.xml
+++ b/src/changelog/3.5.0/313-require-powershell-74.xml
@@ -9,6 +9,6 @@
  `$PSNativeCommandUseErrorActionPreference`, which exists only from 7.4, so under Windows PowerShell
  5.1 a failing `gpg --verify` was ignored and `verify-release.ps1` reported success and exited 0. The
  scripts now refuse to start on an older host, and the review instructions install PowerShell 7 and
- run the script with `pwsh` (audit 1231d72-f009)
+ run the script with `pwsh` (audit 1231d72-f009, implemented by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/313-verify-release-keys-bypass.xml
+++ b/src/changelog/3.5.0/313-verify-release-keys-bypass.xml
@@ -10,6 +10,6 @@
  and was imported into the verification key ring, and artifacts signed by whoever placed it verified
  (CWE-347). The scripts now verify in a GnuPG home of their own, filled from a copy downloaded
  there, rather than with `--keyring`, which `gpg` ignores where `common.conf` sets `use-keyboxd`.
- Present in 3.2.0 onward, since the script was added (audit da18b6fd-f003, reported by @swebb2066)
+ Present in 3.2.0 onward, since the script was added (audit da18b6fd-f003, reported by @swebb2066, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/314-ext-mail-background-sender.xml
+++ b/src/changelog/3.5.0/314-ext-mail-background-sender.xml
@@ -10,6 +10,6 @@
  for the SMTP server. The queue holds `sendQueueSize` mails (500) and a logging call waits at most
  `enqueueTimeoutMillis` (5000) for room in it. Failures are still reported to the error handler,
  but after the logging call has returned, and `Flush` now honours its timeout
- (implemented by @FreeAndNil)
+ (audit da18b6fd-f004, implemented by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/314-ext-mail-send-timeout.xml
+++ b/src/changelog/3.5.0/314-ext-mail-send-timeout.xml
@@ -9,6 +9,6 @@
  per operation by default, and the mail goes out while the appender lock is held, so an
  unresponsive server suspended every thread logging through the appender. `SendTimeoutMillis` is a
  deadline for the send as a whole, because a per operation timeout still allows a multiple of
- itself overall (implemented by @FreeAndNil)
+ itself overall (audit da18b6fd-f004, implemented by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/314-remote-syslog-background-sender.xml
+++ b/src/changelog/3.5.0/314-remote-syslog-background-sender.xml
@@ -9,6 +9,6 @@
  stopped accepting datagrams grew it until the process ran out of memory, and shutdown waited five
  seconds and then abandoned a drain that had no limit of its own. It now holds `sendQueueSize`
  datagrams (500), a logging call waits at most `enqueueTimeoutMillis` (5000) for room, losses are
- counted and reported, and `Flush` honours its timeout (implemented by @FreeAndNil)
+ counted and reported, and `Flush` honours its timeout (audit da18b6fd-f034, implemented by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/314-remote-syslog-socket-and-connect.xml
+++ b/src/changelog/3.5.0/314-remote-syslog-socket-and-connect.xml
@@ -9,6 +9,6 @@
  connection its background pump owns, but also inherited one from `UdpAppender` that nothing ever
  used, which bound `localPort` twice. A pump that cannot connect now reports it as well, instead
  of ending unobserved and leaving every later event queued behind a sender that is gone
- (implemented by @FreeAndNil)
+ (audit da18b6fd-f034, implemented by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/315-eventlog-nul.xml
+++ b/src/changelog/3.5.0/315-eventlog-nul.xml
@@ -10,6 +10,6 @@
  the layout rendered after it, exception text and trailing fields included (CWE-158). `WriteEntry`
  raises nothing, so the record simply stored short. Measured on Windows 11 build 26200: of a 45
  character message with a NUL at 23, the 23 character prefix was stored and the rest was gone
- (audit da18b6fd-f007)
+ (audit da18b6fd-f007, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/315-eventlog-size-budget.xml
+++ b/src/changelog/3.5.0/315-eventlog-size-budget.xml
@@ -12,6 +12,6 @@
  that the service stores nothing and reports nothing. The whole event was lost rather than
  shortened, and `applicationName` defaults to the app domain name, so a consumer with a long
  assembly name lost more. The limit is now computed, and a truncation is reported through the
- error handler, which is the only signal available (audit da18b6fd-f030)
+ error handler, which is the only signal available (audit da18b6fd-f030, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/315-local-syslog-newlines.xml
+++ b/src/changelog/3.5.0/315-local-syslog-newlines.xml
@@ -10,6 +10,6 @@
  records everything after the newline as its own entry, so content could forge an authentic
  looking record (CWE-117). `NewLineHandling` mirrors the option of the same name on
  `RemoteSyslogAppender`, which already escaped by default; set it to `Keep` for the previous
- behaviour (audit da18b6fd-f008)
+ behaviour (audit da18b6fd-f008, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/315-outputdebugstring-nul.xml
+++ b/src/changelog/3.5.0/315-outputdebugstring-nul.xml
@@ -8,6 +8,6 @@
     escape NUL characters in `OutputDebugStringAppender` content. `OutputDebugStringW` takes a null
  terminated string, so a NUL in logged content ended the record there and silently dropped whatever
  the layout rendered after it, exception text and trailing fields included (CWE-158). The escape
- `LocalSyslogAppender` already applied is now shared between the two (audit da18b6fd-f009)
+ `LocalSyslogAppender` already applied is now shared between the two (audit da18b6fd-f009, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/315-pickup-dir-unencodable-content.xml
+++ b/src/changelog/3.5.0/315-pickup-dir-unencodable-content.xml
@@ -8,6 +8,6 @@
     stop one logging event destroying a whole `SmtpPickupDirAppender` batch. `File.CreateText`
  throws on content it cannot encode, such as an unpaired surrogate, which abandoned every buffered
  event and left a truncated mail in the pickup directory for the service to send. Such content is
- now written as a `\uXXXX` escape (audit da18b6fd-f011)
+ now written as a `\uXXXX` escape (audit da18b6fd-f011, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/315-syslog-non-ascii.xml
+++ b/src/changelog/3.5.0/315-syslog-non-ascii.xml
@@ -9,6 +9,6 @@
  allows only the visible ASCII characters and space, and everything else was dropped silently, so
  `Sch&#246;nwetter &#20320;&#22909;` reached the collector as `Schnwetter ` and a tab disappeared
  from between its neighbours. Such characters are now written as a `\uXXXX` escape, which keeps
- the record inside the allowed range and readable (audit da18b6fd-f035)
+ the record inside the allowed range and readable (audit da18b6fd-f035, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/315-telnet-unencodable-content.xml
+++ b/src/changelog/3.5.0/315-telnet-unencodable-content.xml
@@ -8,6 +8,6 @@
     stop one logging event disconnecting every `TelnetAppender` client. The default writer encoding
  throws on content it cannot encode, such as an unpaired surrogate, and `Send` reads any failure as
  a client that hung up. Unpaired surrogates are now written as a `\uXXXX` escape, as elsewhere
- (audit da18b6fd-f013)
+ (audit da18b6fd-f013, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/316-ansi-empty-render.xml
+++ b/src/changelog/3.5.0/316-ansi-empty-render.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="316" link="https://github.com/apache/logging-log4net/pull/316"/>
+  <description format="asciidoc">
+    stop `AnsiColorTerminalAppender` dropping an event that renders to nothing. The branch meant
+ for a single character read the first one without checking there was one, so an empty render
+ threw and the event was lost. The reset codes are now placed by one computed offset, which has no
+ special case to get wrong (audit da18b6fd-f029)
+  </description>
+</entry>

--- a/src/changelog/3.5.0/316-ansi-empty-render.xml
+++ b/src/changelog/3.5.0/316-ansi-empty-render.xml
@@ -8,6 +8,6 @@
     stop `AnsiColorTerminalAppender` dropping an event that renders to nothing. The branch meant
  for a single character read the first one without checking there was one, so an empty render
  threw and the event was lost. The reset codes are now placed by one computed offset, which has no
- special case to get wrong (audit da18b6fd-f029)
+ special case to get wrong (audit da18b6fd-f029, fixed by @FreeAndNil)
   </description>
 </entry>

--- a/src/changelog/3.5.0/316-aspnet-request-event-loss.xml
+++ b/src/changelog/3.5.0/316-aspnet-request-event-loss.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="316" link="https://github.com/apache/logging-log4net/pull/316"/>
+  <description format="asciidoc">Stop `%aspnet-request` losing the whole event for a request that fails
+  ASP.NET request validation. Reading `HttpRequest.Params` validates the query string, form and
+  cookies on first access, so a request carrying `&lt;script&gt;` threw inside the layout and the
+  appender discarded the event: a sender could suppress the log record of their own request. The
+  converter now reads through `HttpRequest.Unvalidated`, which keeps the content instead of
+  dropping it (audit da18b6fd-f019, fixed by @FreeAndNil)</description>
+</entry>

--- a/src/changelog/3.5.0/317-filter-ordinal-substring.xml
+++ b/src/changelog/3.5.0/317-filter-ordinal-substring.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="317" link="https://github.com/apache/logging-log4net/pull/317"/>
+  <description format="asciidoc">Compare `StringToMatch` ordinally in `StringMatchFilter` and `PropertyFilter`.
+  The substring search was culture sensitive, and a linguistic search skips ignorable characters, so
+  content holding a NUL, a soft hyphen or a zero-width space between the letters of the configured
+  text still matched it, and the decision varied with the host culture. The filter now decides the
+  same way a reader of the log would (audit da18b6fd-f018, fixed by @FreeAndNil)</description>
+</entry>

--- a/src/changelog/3.5.0/317-filter-timeout-decision.xml
+++ b/src/changelog/3.5.0/317-filter-timeout-decision.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="317" link="https://github.com/apache/logging-log4net/pull/317"/>
+  <description format="asciidoc">`TimeoutDecision` on `StringMatchFilter` and `PropertyFilter`, deciding an
+  event whose regular expression match was abandoned. An abandoned match was treated as a non-match,
+  but the content decides whether the deadline is reached, so in an `AcceptOnMatch` allowlist
+  followed by a deny-all it let content suppress its own record. The default stays `Neutral`;
+  `Accept` makes such a chain fail towards logging (audit da18b6fd-f017, implemented by
+  @FreeAndNil)</description>
+</entry>

--- a/src/changelog/3.5.0/317-filter-timeout-default.xml
+++ b/src/changelog/3.5.0/317-filter-timeout-default.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="317" link="https://github.com/apache/logging-log4net/pull/317"/>
+  <description format="asciidoc">The default `MatchTimeoutMillis` on `StringMatchFilter` and
+  `PropertyFilter` is now 50 instead of 1000. The match runs while the appender lock is held, so the
+  deadline is the bound on how long one crafted event can stall everything logging through the
+  appender. A legitimate match over an event takes a fraction of 50ms; raise the property if a
+  pattern genuinely needs longer (audit da18b6fd-f041, implemented by @FreeAndNil)</description>
+</entry>

--- a/src/log4net.Tests/Appender/AnsiColorTerminalAppenderTest.cs
+++ b/src/log4net.Tests/Appender/AnsiColorTerminalAppenderTest.cs
@@ -1,0 +1,104 @@
+#region Apache License
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more 
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership. 
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with 
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.IO;
+
+using log4net.Appender;
+using log4net.Core;
+using log4net.Layout;
+
+using NUnit.Framework;
+
+namespace log4net.Tests.Appender;
+
+/// <summary>
+/// Tests for <see cref="AnsiColorTerminalAppender"/>, which places the terminal reset codes
+/// before any trailing line break so the colour ends with the text.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class AnsiColorTerminalAppenderTest
+{
+  /// <summary>Matches the appender's private PostEventCodes.</summary>
+  private const string Reset = "\x1b[0m";
+
+  /// <summary>The reset codes belong before the line break, whichever one it is.</summary>
+  // Explicit names: two arguments where one holds an escape character make the whole fixture
+  // invisible to "dotnet test --filter", reproduced with [TestCase("one", "\x1b[0m")].
+  [TestCase("", Reset, TestName = "AnEmptyRender")]
+  [TestCase("x", "x" + Reset, TestName = "ASingleCharacter")]
+  [TestCase("\n", Reset + "\n", TestName = "NothingButALineFeed")]
+  [TestCase("text", "text" + Reset, TestName = "NoTrailingLineBreak")]
+  [TestCase("\r", Reset + "\r", TestName = "NothingButACarriageReturn")]
+  [TestCase("text\n", "text" + Reset + "\n", TestName = "TrailingLineFeed")]
+  [TestCase("text\r", "text" + Reset + "\r", TestName = "TrailingCarriageReturn")]
+  [TestCase("text\r\n", "text" + Reset + "\r\n", TestName = "TrailingCarriageReturnLineFeed")]
+  [TestCase("text\n\r", "text" + Reset + "\n\r", TestName = "TrailingLineFeedCarriageReturn")]
+  [TestCase("text\n\n", "text\n" + Reset + "\n", TestName = "TrailingDoubledLineFeedCountsAsOne")]
+  public void TheResetCodesGoBeforeATrailingLineBreak(string message, string expected)
+  {
+    RecordingErrorHandler errorHandler = new();
+    // Level.Info has no colour mapping configured, so nothing is prepended and the rendered
+    // message is exactly what was logged, down to the empty string.
+    AnsiColorTerminalAppender appender = new()
+    {
+      Layout = new PatternLayout("%message"),
+      ErrorHandler = errorHandler
+    };
+    appender.ActivateOptions();
+
+    TextWriter previous = Console.Out;
+    using StringWriter captured = new();
+    try
+    {
+      Console.SetOut(captured);
+      // DoAppend is overloaded on LoggingEvent and LoggingEvent[], so this new cannot be short.
+      appender.DoAppend(new LoggingEvent(new()
+      {
+        Level = Level.Info,
+        Message = message,
+        LoggerName = nameof(AnsiColorTerminalAppenderTest)
+      }));
+    }
+    finally
+    {
+      Console.SetOut(previous);
+    }
+
+    Assert.That(errorHandler.Message, Is.Empty, "the event must not be dropped");
+    Assert.That(captured.ToString(), Is.EqualTo(expected));
+  }
+
+  /// <summary>Collects what the appender reports, so a dropped event is visible.</summary>
+  private sealed class RecordingErrorHandler : IErrorHandler
+  {
+    /// <summary>Everything reported so far.</summary>
+    internal string Message { get; private set; } = string.Empty;
+
+    /// <inheritdoc/>
+    public void Error(string message) => Message += message + '\n';
+
+    /// <inheritdoc/>
+    public void Error(string message, Exception e) => Message += message + '\n';
+
+    /// <inheritdoc/>
+    public void Error(string message, Exception? e, ErrorCode errorCode) => Message += message + '\n';
+  }
+}

--- a/src/log4net.Tests/Filter/PropertyFilterTest.cs
+++ b/src/log4net.Tests/Filter/PropertyFilterTest.cs
@@ -1,0 +1,119 @@
+#region Apache License
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+
+using log4net.Core;
+using log4net.Filter;
+using log4net.Repository;
+using log4net.Util;
+
+using NUnit.Framework;
+
+namespace log4net.Tests.Filter;
+
+/// <summary>
+/// Tests for <see cref="PropertyFilter"/>, which decides a property value through the same
+/// matching as <see cref="StringMatchFilter"/>.
+/// </summary>
+[TestFixture]
+public class PropertyFilterTest
+{
+  private const string Key = "user";
+
+  /// <summary>
+  /// A pattern that backtracks, with a value that makes it do so.
+  /// </summary>
+  private const string CatastrophicPattern = "^(a+)+$";
+
+  private const string CraftedValue = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!";
+
+  /// <summary>
+  /// A property value is content too, so an ignorable character must not force a match here
+  /// either.
+  /// </summary>
+  [TestCase("\0", TestName = "ANulDoesNotForceAPropertyMatch")]
+  [TestCase("­", TestName = "ASoftHyphenDoesNotForceAPropertyMatch")]
+  public void AnIgnorableCharacterDoesNotForceAPropertyMatch(string ignorable)
+  {
+    PropertyFilter filter = new() { Key = Key, StringToMatch = "admin", AcceptOnMatch = true };
+    filter.ActivateOptions();
+
+    Assert.That(filter.Decide(CreateEvent($"adm{ignorable}in")), Is.EqualTo(FilterDecision.Neutral));
+  }
+
+  /// <summary>
+  /// The exact value still decides, so the ordinal comparison has not broken the filter.
+  /// </summary>
+  [Test]
+  public void AnExactPropertyValueStillMatches()
+  {
+    PropertyFilter filter = new() { Key = Key, StringToMatch = "admin", AcceptOnMatch = false };
+    filter.ActivateOptions();
+
+    Assert.That(filter.Decide(CreateEvent("admin")), Is.EqualTo(FilterDecision.Deny));
+    Assert.That(filter.Decide(CreateEvent("guest")), Is.EqualTo(FilterDecision.Neutral));
+  }
+
+  /// <summary>
+  /// An abandoned match is decided the same way as in the base filter.
+  /// </summary>
+  [Test]
+  public void AnAbandonedPropertyMatchHonoursTimeoutDecision()
+  {
+    PropertyFilter filter = new()
+    {
+      Key = Key,
+      RegexToMatch = CatastrophicPattern,
+      MatchTimeoutMillis = 50,
+      TimeoutDecision = FilterDecision.Accept
+    };
+    filter.ActivateOptions();
+
+    FilterDecision decision = FilterDecision.Neutral;
+    LogLog.ExecuteWithoutEmittingInternalMessages(() => decision = filter.Decide(CreateEvent(CraftedValue)));
+
+    Assert.That(decision, Is.EqualTo(FilterDecision.Accept));
+  }
+
+  /// <summary>
+  /// Without a key there is nothing to look up, so the chain continues.
+  /// </summary>
+  [Test]
+  public void AFilterWithoutAKeyIsNeutral()
+  {
+    PropertyFilter filter = new() { StringToMatch = "admin" };
+    filter.ActivateOptions();
+
+    Assert.That(filter.Decide(CreateEvent("admin")), Is.EqualTo(FilterDecision.Neutral));
+  }
+
+  /// <summary>
+  /// Builds an event carrying <paramref name="value"/> under <see cref="Key"/>. The filter renders
+  /// the property through the repository, so the event needs one.
+  /// </summary>
+  private static LoggingEvent CreateEvent(string value)
+  {
+    ILoggerRepository repository = LogManager.CreateRepository(Guid.NewGuid().ToString());
+    LoggingEventData data = new() { Level = Level.Info, Message = "TestMessage", LoggerName = "TestLogger" };
+    LoggingEvent loggingEvent = new(null, repository, data);
+    loggingEvent.Properties[Key] = value;
+    return loggingEvent;
+  }
+}

--- a/src/log4net.Tests/Filter/StringMatchFilterTest.cs
+++ b/src/log4net.Tests/Filter/StringMatchFilterTest.cs
@@ -50,7 +50,7 @@ public class StringMatchFilterTest
   [Test]
   public void AMatchThatBacktracksIsAbandoned()
   {
-    StringMatchFilter filter = new() { RegexToMatch = CatastrophicPattern, MatchTimeoutMillis = 100 };
+    StringMatchFilter filter = new() { RegexToMatch = CatastrophicPattern, MatchTimeoutMillis = 50 };
     filter.ActivateOptions();
 
     Stopwatch stopwatch = Stopwatch.StartNew();
@@ -70,7 +70,7 @@ public class StringMatchFilterTest
   [NonParallelizable]
   public void AnAbandonedMatchIsReportedOnce()
   {
-    StringMatchFilter filter = new() { RegexToMatch = CatastrophicPattern, MatchTimeoutMillis = 100 };
+    StringMatchFilter filter = new() { RegexToMatch = CatastrophicPattern, MatchTimeoutMillis = 50 };
     filter.ActivateOptions();
 
     List<LogLog> messages = [];
@@ -101,12 +101,72 @@ public class StringMatchFilterTest
   }
 
   /// <summary>
-  /// The deadline has to be finite by default, so that an expensive pattern cannot hold the
-  /// appender lock indefinitely without the operator having opted into that.
+  /// The deadline bounds how long one crafted event holds the appender lock, so it has to be
+  /// finite by default and short enough to matter.
   /// </summary>
   [Test]
   public void MatchTimeoutMillisDefaultsToAFiniteValue()
-    => Assert.That(new StringMatchFilter().MatchTimeoutMillis, Is.EqualTo(1000));
+    => Assert.That(new StringMatchFilter().MatchTimeoutMillis, Is.EqualTo(50));
+
+  /// <summary>
+  /// An abandoned match leaves the chain to decide unless the operator says otherwise, so the
+  /// default has to stay Neutral.
+  /// </summary>
+  [Test]
+  public void TimeoutDecisionDefaultsToNeutral()
+    => Assert.That(new StringMatchFilter().TimeoutDecision, Is.EqualTo(FilterDecision.Neutral));
+
+  /// <summary>
+  /// The content decides whether the deadline is reached, so an allowlist that treats an abandoned
+  /// match as a non-match lets content suppress its own record. TimeoutDecision is how such a
+  /// chain fails towards logging instead.
+  /// </summary>
+  [TestCase(FilterDecision.Deny, TestName = "AnAbandonedMatchIsDecidedByTimeoutDecisionDeny")]
+  [TestCase(FilterDecision.Accept, TestName = "AnAbandonedMatchIsDecidedByTimeoutDecisionAccept")]
+  [TestCase(FilterDecision.Neutral, TestName = "AnAbandonedMatchIsDecidedByTimeoutDecisionNeutral")]
+  public void AnAbandonedMatchIsDecidedByTimeoutDecision(FilterDecision timeoutDecision)
+  {
+    StringMatchFilter filter = new()
+    {
+      RegexToMatch = CatastrophicPattern,
+      MatchTimeoutMillis = 50,
+      TimeoutDecision = timeoutDecision
+    };
+    filter.ActivateOptions();
+
+    FilterDecision decision = FilterDecision.Accept;
+    LogLog.ExecuteWithoutEmittingInternalMessages(() => decision = filter.Decide(CreateEvent(CraftedMessage)));
+
+    Assert.That(decision, Is.EqualTo(timeoutDecision));
+  }
+
+  /// <summary>
+  /// A linguistic search skips ignorable characters, so content could otherwise force a substring
+  /// match that no ordinal reader of the same log would make.
+  /// </summary>
+  [TestCase("\0", TestName = "ANulDoesNotForceASubstringMatch")]
+  [TestCase("­", TestName = "ASoftHyphenDoesNotForceASubstringMatch")]
+  [TestCase("​", TestName = "AZeroWidthSpaceDoesNotForceASubstringMatch")]
+  public void AnIgnorableCharacterDoesNotForceASubstringMatch(string ignorable)
+  {
+    StringMatchFilter filter = new() { StringToMatch = "password", AcceptOnMatch = true };
+    filter.ActivateOptions();
+
+    Assert.That(filter.Decide(CreateEvent($"pass{ignorable}word")), Is.EqualTo(FilterDecision.Neutral));
+  }
+
+  /// <summary>
+  /// The ordinal comparison must not break the match it exists to protect.
+  /// </summary>
+  [Test]
+  public void AnExactSubstringStillMatches()
+  {
+    StringMatchFilter filter = new() { StringToMatch = "password", AcceptOnMatch = true };
+    filter.ActivateOptions();
+
+    Assert.That(filter.Decide(CreateEvent("a password here")), Is.EqualTo(FilterDecision.Accept));
+    Assert.That(filter.Decide(CreateEvent("nothing here")), Is.EqualTo(FilterDecision.Neutral));
+  }
 
   /// <summary>
   /// 0 is the documented opt-out that restores unbounded matching; a negative deadline has no

--- a/src/log4net.Tests/Layout/Pattern/AspNetRequestPatternConverterTest.cs
+++ b/src/log4net.Tests/Layout/Pattern/AspNetRequestPatternConverterTest.cs
@@ -1,0 +1,147 @@
+#region Apache License
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+// netstandard has no System.Web
+#if NET462_OR_GREATER
+
+using System;
+using System.IO;
+using System.Web;
+
+using log4net.Config;
+using log4net.Layout;
+using log4net.Repository;
+using log4net.Tests.Appender;
+using log4net.Util;
+
+using NUnit.Framework;
+
+namespace log4net.Tests.Layout.Pattern;
+
+/// <summary>
+/// Tests that <c>%aspnet-request</c> survives content ASP.NET request validation rejects.
+/// </summary>
+[TestFixture]
+public sealed class AspNetRequestPatternConverterTest
+{
+  private const string Payload = "<script>";
+
+  /// <summary>
+  /// Detaches the hand-built request from the thread again.
+  /// </summary>
+  [TearDown]
+  public void TearDown() => HttpContext.Current = null;
+
+  /// <summary>
+  /// Guards the other tests: if request validation does not fire here, they pass vacuously.
+  /// </summary>
+  [Test]
+  [NonParallelizable]
+  public void TheRequestUsedByTheseTestsDoesFailValidation()
+  {
+    HttpRequest request = CurrentRequest("q=%3Cscript%3E");
+
+    Assert.Throws<HttpRequestValidationException>(() => _ = request.Params);
+  }
+
+  /// <summary>
+  /// Reading a named field of a request that fails validation once threw inside the layout, and
+  /// the appender discarded the whole event, letting a sender suppress the record of their own
+  /// request.
+  /// </summary>
+  [Test]
+  [NonParallelizable]
+  public void ARejectedNamedFieldKeepsItsContent()
+  {
+    CurrentRequest("q=%3Cscript%3E");
+
+    string rendered = Render("%aspnet-request{q}|%message");
+
+    Assert.That(rendered, Is.EqualTo(Payload + "|TestMessage"));
+  }
+
+  /// <summary>
+  /// The same for the whole collection, which has no unvalidated counterpart and is rebuilt.
+  /// </summary>
+  [Test]
+  [NonParallelizable]
+  public void ARejectedRequestStillWritesTheEvent()
+  {
+    CurrentRequest("q=%3Cscript%3E");
+
+    string rendered = Render("%aspnet-request|%message");
+
+    Assert.That(rendered, Does.EndWith("|TestMessage"));
+  }
+
+  /// <summary>
+  /// A benign request is unchanged, so the paths above are not hiding a broken happy path.
+  /// </summary>
+  [Test]
+  [NonParallelizable]
+  public void ABenignNamedFieldIsUnchanged()
+  {
+    CurrentRequest("name=value");
+
+    string rendered = Render("%aspnet-request{name}|%message");
+
+    Assert.That(rendered, Is.EqualTo("value|TestMessage"));
+  }
+
+  /// <summary>
+  /// Without a request the converter writes the not-available marker rather than failing.
+  /// </summary>
+  [Test]
+  [NonParallelizable]
+  public void NoHttpContextWritesTheNotAvailableMarker()
+  {
+    HttpContext.Current = null;
+
+    string rendered = Render("%aspnet-request{q}|%message");
+
+    Assert.That(rendered, Is.EqualTo(SystemInfo.NotAvailableText + "|TestMessage"));
+  }
+
+  /// <summary>
+  /// Publishes a request carrying <paramref name="queryString"/> and opts it into validation.
+  /// </summary>
+  private static HttpRequest CurrentRequest(string queryString)
+  {
+    HttpRequest request = new("page.aspx", "http://localhost/page.aspx", queryString);
+    HttpContext.Current = new(request, new HttpResponse(TextWriter.Null));
+    // The runtime does this for a real request; the first Params read then validates.
+    request.ValidateInput();
+    return request;
+  }
+
+  /// <summary>
+  /// Logs one event through <paramref name="pattern"/> and returns what the appender received.
+  /// </summary>
+  private static string Render(string pattern)
+  {
+    StringAppender appender = new() { Layout = new PatternLayout(pattern) };
+    ILoggerRepository repository = LogManager.CreateRepository(Guid.NewGuid().ToString());
+    BasicConfigurator.Configure(repository, appender);
+    LogManager.GetLogger(repository.Name, nameof(AspNetRequestPatternConverterTest))
+      .Info("TestMessage");
+    return appender.GetString();
+  }
+}
+
+#endif // NET462_OR_GREATER

--- a/src/log4net.Tests/log4net.Tests.csproj
+++ b/src/log4net.Tests/log4net.Tests.csproj
@@ -38,6 +38,7 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Remoting" />
+    <Reference Include="System.Web" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net10.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNetTestSdkPackageVersion)" />

--- a/src/log4net/Appender/AnsiColorTerminalAppender.cs
+++ b/src/log4net/Appender/AnsiColorTerminalAppender.cs
@@ -251,36 +251,10 @@ public class AnsiColorTerminalAppender : AppenderSkeleton
       loggingMessage = levelColors.CombinedColor + loggingMessage;
     }
 
-    // on most terminals there are weird effects if we don't clear the background color
-    // before the new line.  This checks to see if it ends with a newline, and if
-    // so, inserts the clear codes before the newline, otherwise the clear codes
-    // are inserted afterward.
-    if (loggingMessage.Length > 1)
-    {
-      if (loggingMessage.EndsWith("\r\n") || loggingMessage.EndsWith("\n\r"))
-      {
-        loggingMessage = loggingMessage.Insert(loggingMessage.Length - 2, PostEventCodes);
-      }
-      else if (loggingMessage.EndsWith("\n") || loggingMessage.EndsWith("\r"))
-      {
-        loggingMessage = loggingMessage.Insert(loggingMessage.Length - 1, PostEventCodes);
-      }
-      else
-      {
-        loggingMessage += PostEventCodes;
-      }
-    }
-    else
-    {
-      if (loggingMessage[0] is '\n' or '\r')
-      {
-        loggingMessage = PostEventCodes + loggingMessage;
-      }
-      else
-      {
-        loggingMessage += PostEventCodes;
-      }
-    }
+    // On most terminals there are weird effects if the background colour is not cleared before
+    // the line break, so the reset codes go before it rather than after.
+    loggingMessage = loggingMessage.Insert(
+      loggingMessage.Length - TrailingLineBreakLength(loggingMessage), PostEventCodes);
 
     if (_writeToErrorStream)
     {
@@ -293,6 +267,23 @@ public class AnsiColorTerminalAppender : AppenderSkeleton
       Console.Write(loggingMessage);
     }
 
+  }
+
+  /// <summary>
+  /// How many characters of line break the message ends with, 0, 1 or 2.
+  /// </summary>
+  private static int TrailingLineBreakLength(string message)
+  {
+    int last = message.Length - 1;
+    if (last < 0 || message[last] is not '\n' and not '\r')
+    {
+      return 0;
+    }
+
+    int previous = last - 1;
+    return previous >= 0 && message[previous] is '\n' or '\r' && message[previous] != message[last]
+      ? 2
+      : 1;
   }
 
   /// <summary>

--- a/src/log4net/Filter/PropertyFilter.cs
+++ b/src/log4net/Filter/PropertyFilter.cs
@@ -76,46 +76,11 @@ public class PropertyFilter : StringMatchFilter
       return FilterDecision.Neutral;
     }
 
-    // Lookup the string to match in from the properties using 
+    // Lookup the string to match in from the properties using
     // the key specified.
     object? msgObj = loggingEvent.LookupProperty(Key);
 
     // Use an ObjectRenderer to convert the property value to a string
-    string? msg = loggingEvent.Repository?.RendererMap.FindAndRender(msgObj);
-
-    // Check if we have been setup to filter
-    if (msg is null || (StringToMatch is null && m_regexToMatch is null))
-    {
-      // We cannot filter so allow the filter chain
-      // to continue processing
-      return FilterDecision.Neutral;
-    }
-
-    // Firstly check if we are matching using a regex
-    if (m_regexToMatch is not null)
-    {
-      // Check the regex
-      if (!IsRegexMatch(msg))
-      {
-        // No match, continue processing
-        return FilterDecision.Neutral;
-      }
-
-      // we've got a match
-      return AcceptOnMatch ? FilterDecision.Accept : FilterDecision.Deny;
-    }
-    else if (StringToMatch is not null)
-    {
-      // Check substring match
-      if (msg.IndexOf(StringToMatch) == -1)
-      {
-        // No match, continue processing
-        return FilterDecision.Neutral;
-      }
-
-      // we've got a match
-      return AcceptOnMatch ? FilterDecision.Accept : FilterDecision.Deny;
-    }
-    return FilterDecision.Neutral;
+    return DecideOnValue(loggingEvent.Repository?.RendererMap.FindAndRender(msgObj));
   }
 }

--- a/src/log4net/Filter/StringMatchFilter.cs
+++ b/src/log4net/Filter/StringMatchFilter.cs
@@ -76,16 +76,18 @@ public class StringMatchFilter : FilterSkeleton
   /// <para>
   /// A regular expression that backtracks can take a very long time on some inputs. The pattern is
   /// matched while the appender lock is held, so an unbounded match would stall everything logging
-  /// through the appender, and matching is therefore given a deadline. A match that reaches it is
-  /// treated as no match, leaving the rest of the filter chain to decide.
+  /// through the appender, and matching is therefore given a deadline. <see cref="TimeoutDecision"/>
+  /// decides an event whose match is abandoned.
   /// </para>
   /// <para>
-  /// The pattern comes from configuration and is trusted, so this is a guard against a pattern that
-  /// turns out to be expensive rather than protection against untrusted input.
+  /// The pattern comes from configuration and is trusted, but the content it is matched against is
+  /// not, and the content decides whether the deadline is reached. This is therefore the bound on
+  /// how long one crafted event can hold the appender lock.
   /// </para>
   /// <para>
-  /// The default value is 1000 (one second). Setting the value to 0 restores unbounded matching and
-  /// is not recommended. Changing it takes effect when <see cref="ActivateOptions"/> is called.
+  /// The default value is 50. A legitimate match over an event runs in a fraction of that; raise it
+  /// if a pattern genuinely needs longer. Setting the value to 0 restores unbounded matching and is
+  /// not recommended. Changing it takes effect when <see cref="ActivateOptions"/> is called.
   /// </para>
   /// </remarks>
   /// <exception cref="ArgumentOutOfRangeException">The value specified is negative.</exception>
@@ -103,8 +105,33 @@ public class StringMatchFilter : FilterSkeleton
     }
   }
 
-  private int _matchTimeoutMillis = 1000;
+  private int _matchTimeoutMillis = 50;
   private bool _matchTimeoutReported;
+
+  /// <summary>
+  /// Gets or sets the decision for an event whose match was abandoned because it reached
+  /// <see cref="MatchTimeoutMillis"/>.
+  /// </summary>
+  /// <remarks>
+  /// <para>
+  /// An abandoned match is not a non-match: the content being matched decides whether the deadline
+  /// is reached, so treating it as "did not match" lets content choose its own outcome. In an
+  /// <see cref="AcceptOnMatch"/> allowlist followed by a deny-all, that means content can suppress
+  /// its own record.
+  /// </para>
+  /// <para>
+  /// The default is <see cref="FilterDecision.Neutral"/>, which leaves the rest of the chain to
+  /// decide. Set <see cref="FilterDecision.Accept"/> to make an allowlist fail towards logging, or
+  /// <see cref="FilterDecision.Deny"/> in a deny-on-match chain. No one direction is right for
+  /// every chain, which is why this is configured rather than chosen here.
+  /// </para>
+  /// </remarks>
+  public FilterDecision TimeoutDecision { get; set; } = FilterDecision.Neutral;
+
+  /// <summary>
+  /// The decision a match produces, per <see cref="AcceptOnMatch"/>.
+  /// </summary>
+  private FilterDecision MatchDecision => AcceptOnMatch ? FilterDecision.Accept : FilterDecision.Deny;
 
   /// <summary>
   /// Matches <paramref name="value"/> against <see cref="m_regexToMatch"/>.
@@ -114,25 +141,72 @@ public class StringMatchFilter : FilterSkeleton
   /// <see langword="true"/> when the pattern matches, and <see langword="false"/> when it does not
   /// or when matching took longer than <see cref="MatchTimeoutMillis"/>.
   /// </returns>
-  protected bool IsRegexMatch(string value)
+  protected bool IsRegexMatch(string value) => TryRegexMatch(value, out bool isMatch) && isMatch;
+
+  /// <summary>
+  /// Decides <paramref name="value"/> on the pattern, honouring <see cref="TimeoutDecision"/>.
+  /// </summary>
+  /// <param name="value">The text to match.</param>
+  /// <returns>The decision for the event the text came from.</returns>
+  protected FilterDecision DecideRegexMatch(string value)
+    => TryRegexMatch(value, out bool isMatch)
+      ? isMatch 
+        ? MatchDecision
+        : FilterDecision.Neutral
+      : TimeoutDecision;
+
+  /// <summary>
+  /// Matches <paramref name="value"/>, reporting an abandoned match once per filter.
+  /// </summary>
+  /// <returns><see langword="false"/> when the match was abandoned.</returns>
+  private bool TryRegexMatch(string value, out bool isMatch)
   {
     try
     {
-      return m_regexToMatch!.IsMatch(value);
+      isMatch = m_regexToMatch!.IsMatch(value);
+      return true;
     }
     catch (RegexMatchTimeoutException)
     {
+      isMatch = false;
       if (!_matchTimeoutReported)
       {
         // Once per filter. The condition repeats for every event that reaches it, and a warning
         // per event would be a denial of service of its own.
         _matchTimeoutReported = true;
         LogLog.Warn(_declaringType,
-          $"Matching the pattern [{RegexToMatch}] took longer than {MatchTimeoutMillis}ms and was abandoned, so the event was not filtered by it. "
-          + "A pattern that backtracks can take arbitrarily long on some inputs; consider rewriting it or raising MatchTimeoutMillis.");
+          $"Matching the pattern [{RegexToMatch}] took longer than {MatchTimeoutMillis}ms and was abandoned, so the event was decided as {TimeoutDecision}. "
+          + "A pattern that backtracks can take arbitrarily long on some inputs; consider rewriting it, raising MatchTimeoutMillis or setting TimeoutDecision.");
       }
       return false;
     }
+  }
+
+  /// <summary>
+  /// Decides <paramref name="value"/> on <see cref="RegexToMatch"/> or <see cref="StringToMatch"/>.
+  /// </summary>
+  /// <param name="value">The text to match, or <see langword="null"/> when there is none.</param>
+  /// <returns>
+  /// <see cref="FilterDecision.Neutral"/> when there is nothing to match or nothing to match it
+  /// against, otherwise the decision for the event the text came from.
+  /// </returns>
+  protected FilterDecision DecideOnValue(string? value)
+  {
+    if (value is null)
+    {
+      return FilterDecision.Neutral;
+    }
+
+    if (m_regexToMatch is not null)
+    {
+      return DecideRegexMatch(value);
+    }
+
+    // Ordinal: a linguistic search skips ignorable characters, so content holding a NUL, a soft
+    // hyphen or a combining mark could otherwise flip the decision.
+    return StringToMatch is not null && value.IndexOf(StringToMatch, StringComparison.Ordinal) >= 0
+      ? MatchDecision
+      : FilterDecision.Neutral;
   }
 
   /// <summary>
@@ -207,52 +281,6 @@ public class StringMatchFilter : FilterSkeleton
   /// <see cref="FilterDecision.Deny"/> is returned.
   /// </para>
   /// </remarks>
-  public override FilterDecision Decide(LoggingEvent loggingEvent) 
-  {
-    string? msg = loggingEvent.EnsureNotNull().RenderedMessage;
-
-    // Check if we have been setup to filter
-    if (msg is null || (StringToMatch is null && m_regexToMatch is null))
-    {
-      // We cannot filter so allow the filter chain
-      // to continue processing
-      return FilterDecision.Neutral;
-    }
-  
-    // Firstly check if we are matching using a regex
-    if (m_regexToMatch is not null)
-    {
-      // Check the regex
-      if (!IsRegexMatch(msg))
-      {
-        // No match, continue processing
-        return FilterDecision.Neutral;
-      }
-
-      // we've got a match
-      if (AcceptOnMatch) 
-      {
-        return FilterDecision.Accept;
-      } 
-      return FilterDecision.Deny;
-    }
-    else if (StringToMatch is not null)
-    {
-      // Check substring match
-      if (msg.IndexOf(StringToMatch) == -1) 
-      {
-        // No match, continue processing
-        return FilterDecision.Neutral;
-      } 
-
-      // we've got a match
-      if (AcceptOnMatch) 
-      {
-        return FilterDecision.Accept;
-      } 
-      return FilterDecision.Deny;
-    }
-
-    return FilterDecision.Neutral;
-  }
+  public override FilterDecision Decide(LoggingEvent loggingEvent)
+    => DecideOnValue(loggingEvent.EnsureNotNull().RenderedMessage);
 }

--- a/src/log4net/Layout/Pattern/AspNetRequestPatternConverter.cs
+++ b/src/log4net/Layout/Pattern/AspNetRequestPatternConverter.cs
@@ -18,6 +18,7 @@
 //
 #endregion
 
+using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Web;
@@ -53,34 +54,40 @@ internal sealed class AspNetRequestPatternConverter : AspNetPatternLayoutConvert
   /// </remarks>
   protected override void Convert(TextWriter writer, LoggingEvent loggingEvent, HttpContext httpContext)
   {
-    HttpRequest? request = null;
+    object? value;
     try
     {
-      request = httpContext.Request;
+      HttpRequest request = httpContext.Request;
+      // Unvalidated reads past ASP.NET request validation, which throws on content like "<script>".
+      value = Option is null ? GetParameters(request) : request.Unvalidated[Option];
     }
     catch (HttpException)
     {
-      // likely a case of running in IIS integrated mode
-      // when inside an Application_Start event.
-      // treat it like a case of the Request
-      // property returning null
+      // No readable request: IIS integrated mode during Application_Start, an oversized body,
+      // or a client that went away.
+      writer.Write(SystemInfo.NotAvailableText);
+      return;
     }
 
-    if (request is not null)
+    WriteObject(writer, loggingEvent.Repository, value);
+  }
+
+  /// <summary>
+  /// Rebuilds <see cref="HttpRequest.Params"/> from the unvalidated values.
+  /// </summary>
+  private static NameValueCollection GetParameters(HttpRequest request)
+  {
+    UnvalidatedRequestValues unvalidated = request.Unvalidated;
+    NameValueCollection parameters = new();
+    parameters.Add(unvalidated.QueryString);
+    parameters.Add(unvalidated.Form);
+    HttpCookieCollection cookies = unvalidated.Cookies;
+    foreach (string name in cookies.AllKeys)
     {
-      if (Option is not null)
-      {
-        WriteObject(writer, loggingEvent.Repository, httpContext.Request.Params[Option]);
-      }
-      else
-      {
-        WriteObject(writer, loggingEvent.Repository, httpContext.Request.Params);
-      }
+      parameters.Add(name, cookies[name]?.Value);
     }
-    else
-    {
-      writer.Write(SystemInfo.NotAvailableText);
-    }
+    parameters.Add(request.ServerVariables);
+    return parameters;
   }
 }
 

--- a/src/site/antora/modules/ROOT/pages/manual/configuration/filters.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/configuration/filters.adoc
@@ -103,17 +103,43 @@ of a `stringToMatch`.
 
 A regular expression that backtracks can take a very long time on some inputs, and the match runs
 while the appender lock is held.
-Matching is therefore given a deadline of one second, configurable with `matchTimeoutMillis`.
-A match that reaches the deadline is abandoned, the filter reports it once and returns `Neutral`,
-and the remaining filters decide the event.
+The deadline is therefore what bounds how long one event can stall every thread logging through the
+appender, and it defaults to 50 milliseconds, configurable with `matchTimeoutMillis`.
+A legitimate match over an event takes a fraction of that; raise it only if a pattern genuinely
+needs longer.
 Prefer a pattern that cannot backtrack; the deadline is a safety net, not a substitute.
 
 [source,xml]
 ----
 <filter type="log4net.Filter.StringMatchFilter">
   <regexToMatch value="user=[a-z0-9._-]+@example\.com" />
-  <matchTimeoutMillis value="1000" />
+  <matchTimeoutMillis value="200" />
 </filter>
 ----
 
 Setting `matchTimeoutMillis` to `0` lets a match run for as long as it takes and is not recommended.
+
+[#filters-regex-timeout-decision]
+=== Deciding an abandoned match
+
+A match that reaches the deadline is abandoned and the filter reports it once.
+The event is then decided by `timeoutDecision`, which defaults to `Neutral`, leaving the remaining
+filters to decide as before.
+
+An abandoned match is not the same as a non-match: the content being matched is what decides whether
+the deadline is reached, so treating it as "did not match" lets content choose its own outcome.
+In the allowlist arrangement above, where a matching filter accepts and a `DenyAllFilter` ends the
+chain, that means an event can suppress its own record.
+Set `timeoutDecision` to `Accept` there so the chain fails towards logging:
+
+[source,xml]
+----
+<filter type="log4net.Filter.StringMatchFilter">
+  <regexToMatch value="user=[a-z0-9._-]+@example\.com" />
+  <timeoutDecision value="Accept" />
+</filter>
+<filter type="log4net.Filter.DenyAllFilter" />
+----
+
+In a chain that denies on match, `Deny` is the equivalent choice.
+No one direction is right for every chain, which is why it is configured rather than chosen for you.


### PR DESCRIPTION
Three findings, one commit: all three sit in `StringMatchFilter`, whose `Decide`
was a near-duplicate of `PropertyFilter.Decide`, so each defect existed at two
sites. Both now share one implementation, which is also why `MdcFilter` and
`NdcFilter` need no change.

- **f018** The substring search was culture sensitive, and a linguistic search
  skips ignorable characters, so content holding a NUL, a soft hyphen or a
  zero-width space between the letters of `stringToMatch` still matched it, and
  the decision varied with the host culture. Ordinal now, so the filter decides
  the same way a reader of the log would.
- **f017** An abandoned regex match was treated as a non-match. But the content
  decides whether the deadline is reached, so in an `AcceptOnMatch` allowlist
  ending in a `DenyAllFilter`, content could suppress its own record. The new
  `timeoutDecision` decides those events, still `Neutral` by default; `Accept`
  makes such a chain fail towards logging.
- **f041** The default `matchTimeoutMillis` drops from 1000 to 50. The match runs
  under the appender lock, so the deadline bounds what one crafted event costs
  every other logging thread. A legitimate match takes a fraction of that.
  
`filters.adoc` documented the old deadline and outcome, and its example set the
value back to 1000; both corrected, and `timeoutDecision` is documented against
the allowlist arrangement the same page recommends.

Deliberate default change: **f041**. An operator whose pattern genuinely needs
longer must now set `matchTimeoutMillis`, and gets the existing once-per-filter
warning if a match is abandoned.

Tests: 13 new across both filters, and each fix was checked by reverting it and
confirming the right tests fail (5 for f018, 3 for f017, 1 for f041).