### PR TITLE
Prevent Telnet clients reaching or stalling the application

### DIFF
--- a/src/changelog/3.5.0/318-telnet-background-send.xml
+++ b/src/changelog/3.5.0/318-telnet-background-send.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="318" link="https://github.com/apache/logging-log4net/pull/318"/>
+  <description format="asciidoc">Write to `TelnetAppender` clients from a background thread. Clients
+  were written to under the appender lock, so one that stopped reading blocked every thread that
+  logs for `sendTimeoutMillis`, and the writes are serial, so 20 connected clients cost 20 times
+  that on a single event. Events are queued now, bounded by the new `sendQueueSize` (500), and a
+  logging call waits at most `enqueueTimeoutMillis` (50) for room before the event is dropped from
+  the telnet stream, counted and reported. Only the telnet view is lost, never the log. While the
+  queue stays full, `enqueueTimeoutMillis` caps logging at 20 events per second; set it to 0 to drop
+  immediately instead of waiting (audit da18b6fd-f014, implemented by @FreeAndNil)</description>
+</entry>

--- a/src/changelog/3.5.0/318-telnet-loopback-default.xml
+++ b/src/changelog/3.5.0/318-telnet-loopback-default.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="318" link="https://github.com/apache/logging-log4net/pull/318"/>
+  <description format="asciidoc">`TelnetAppender` now listens on `127.0.0.1` by default instead of every
+  interface. The stream is unauthenticated and unencrypted, so any host that could reach the port
+  could read the application's log, and every documented example already used loopback. Watching the
+  log from another machine is now opt-in: set `listenAddress` to `0.0.0.0` or `::` to restore the old
+  behaviour. The `SocketHandler(port, sendTimeoutMillis)` constructor defaults the same way (audit
+  da18b6fd-f012, implemented by @FreeAndNil)</description>
+</entry>

--- a/src/log4net.Tests/Appender/AnsiColorTerminalAppenderTest.cs
+++ b/src/log4net.Tests/Appender/AnsiColorTerminalAppenderTest.cs
@@ -22,6 +22,7 @@ using System.IO;
 
 using log4net.Appender;
 using log4net.Core;
+using log4net.Tests.Appender.Internal;
 using log4net.Layout;
 
 using NUnit.Framework;
@@ -82,23 +83,8 @@ public class AnsiColorTerminalAppenderTest
       Console.SetOut(previous);
     }
 
-    Assert.That(errorHandler.Message, Is.Empty, "the event must not be dropped");
+    Assert.That(errorHandler.Messages, Is.Empty, "the event must not be dropped");
     Assert.That(captured.ToString(), Is.EqualTo(expected));
   }
 
-  /// <summary>Collects what the appender reports, so a dropped event is visible.</summary>
-  private sealed class RecordingErrorHandler : IErrorHandler
-  {
-    /// <summary>Everything reported so far.</summary>
-    internal string Message { get; private set; } = string.Empty;
-
-    /// <inheritdoc/>
-    public void Error(string message) => Message += message + '\n';
-
-    /// <inheritdoc/>
-    public void Error(string message, Exception e) => Message += message + '\n';
-
-    /// <inheritdoc/>
-    public void Error(string message, Exception? e, ErrorCode errorCode) => Message += message + '\n';
-  }
 }

--- a/src/log4net.Tests/Appender/Internal/RecordingErrorHandler.cs
+++ b/src/log4net.Tests/Appender/Internal/RecordingErrorHandler.cs
@@ -1,0 +1,44 @@
+#region Apache License
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+using log4net.Core;
+
+namespace log4net.Tests.Appender.Internal;
+
+/// <summary>
+/// Collects what an appender reports instead of letting it reach the console, so a test can
+/// assert on it and a provoked error adds no noise to the suite output.
+/// </summary>
+internal sealed class RecordingErrorHandler : IErrorHandler
+{
+  /// <summary>Reported messages, in the order they were reported.</summary>
+  internal List<string> Messages { get; } = [];
+
+  /// <inheritdoc/>
+  public void Error(string message) => Messages.Add(message);
+
+  /// <inheritdoc/>
+  public void Error(string message, Exception e) => Messages.Add(message);
+
+  /// <inheritdoc/>
+  public void Error(string message, Exception? e, ErrorCode errorCode) => Messages.Add(message);
+}

--- a/src/log4net.Tests/Appender/Internal/SimpleTelnetClient.cs
+++ b/src/log4net.Tests/Appender/Internal/SimpleTelnetClient.cs
@@ -41,6 +41,24 @@ internal sealed class SimpleTelnetClient(
   private volatile bool _disposing;
 
   /// <summary>
+  /// Connects, reads the welcome message and then stops reading, so this client's receive window
+  /// fills and writes to it block. The opposite of <see cref="Run"/>, for testing that a client
+  /// which stops reading cannot hold up the threads that log.
+  /// </summary>
+  internal void ConnectAndStopReading()
+  {
+    // The kernel clamps this to its minimum, 2304 bytes on Linux, so asking for less buys nothing:
+    // measured, 1, 128, 512 and 1024 all block the writer after the same 960 KB, while 4096 needs
+    // 1748 KB and 16384 needs 2364 KB. The rest of the threshold is the writer's own send buffer,
+    // which is not reachable from here.
+    _client.ReceiveBufferSize = 1_024;
+    _client.ReceiveTimeout = 30_000;
+    _client.Connect(new IPEndPoint(IPAddress.Loopback, port));
+    // Reading one byte of the welcome message proves the appender accepted the connection.
+    _client.GetStream().Read(new byte[1], 0, 1);
+  }
+
+  /// <summary>
   /// Runs the client (in a task)
   /// </summary>
   /// <param name="log">Callback for unexpected errors - a passing run stays silent</param>

--- a/src/log4net.Tests/Appender/RemoteSyslogAppenderTest.cs
+++ b/src/log4net.Tests/Appender/RemoteSyslogAppenderTest.cs
@@ -51,22 +51,6 @@ public sealed class RemoteSyslogAppenderTest
     internal System.Net.Sockets.UdpClient? InheritedClient => Client;
   }
 
-  /// <summary>Collects reported errors instead of letting them reach the console.</summary>
-  private sealed class RecordingErrorHandler : IErrorHandler
-  {
-    /// <summary>Reported messages.</summary>
-    internal List<string> Messages { get; } = [];
-
-    /// <inheritdoc/>
-    public void Error(string message, Exception? e, ErrorCode errorCode) => Messages.Add(message);
-
-    /// <inheritdoc/>
-    public void Error(string message, Exception e) => Messages.Add(message);
-
-    /// <inheritdoc/>
-    public void Error(string message) => Messages.Add(message);
-  }
-
   private const int FlushTimeoutMillis = 30_000;
 
   /// <summary>

--- a/src/log4net.Tests/Appender/SmtpAppenderTest.cs
+++ b/src/log4net.Tests/Appender/SmtpAppenderTest.cs
@@ -18,7 +18,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
@@ -27,9 +26,9 @@ using System.Threading.Tasks;
 
 using log4net.Appender;
 using log4net.Config;
-using log4net.Core;
 using log4net.Layout;
 using log4net.Repository;
+using log4net.Tests.Appender.Internal;
 using log4net.Util;
 
 using NUnit.Framework;
@@ -120,19 +119,4 @@ public class SmtpAppenderTest
     }
   }
 
-  /// <summary>Collects reported errors instead of letting them reach the console.</summary>
-  private sealed class RecordingErrorHandler : IErrorHandler
-  {
-    /// <summary>Reported messages.</summary>
-    internal List<string> Messages { get; } = [];
-
-    /// <inheritdoc/>
-    public void Error(string message, Exception? e, ErrorCode errorCode) => Messages.Add(message);
-
-    /// <inheritdoc/>
-    public void Error(string message, Exception e) => Messages.Add(message);
-
-    /// <inheritdoc/>
-    public void Error(string message) => Messages.Add(message);
-  }
 }

--- a/src/log4net.Tests/Appender/TelnetAppenderTest.cs
+++ b/src/log4net.Tests/Appender/TelnetAppenderTest.cs
@@ -239,12 +239,21 @@ public sealed class TelnetAppenderTest
   }
 
   /// <summary>
-  /// The appender accepts connections on every interface unless told otherwise, which is the
-  /// behaviour it has always had.
+  /// The stream is unauthenticated, so an appender nobody configured an address for must not be
+  /// reachable from another machine.
   /// </summary>
   [Test]
-  public void ListenAddressDefaultsToEveryInterface()
-    => Assert.That(new TelnetAppender().ListenAddress, Is.EqualTo(IPAddress.Any));
+  public void ListenAddressDefaultsToLoopback()
+    => Assert.That(new TelnetAppender().ListenAddress, Is.EqualTo(IPAddress.Loopback));
+
+  /// <summary>
+  /// Remote monitoring is still available, it just has to be asked for.
+  /// </summary>
+  [TestCase("::", TestName = "EveryIPv6InterfaceCanBeAskedFor")]
+  [TestCase("0.0.0.0", TestName = "EveryIPv4InterfaceCanBeAskedFor")]
+  public void EveryInterfaceCanBeAskedFor(string address)
+    => Assert.That(new TelnetAppender { ListenAddress = IPAddress.Parse(address) }.ListenAddress,
+      Is.EqualTo(IPAddress.Parse(address)));
 
   /// <summary>
   /// Binding to the loopback address has to keep the port unreachable from other machines, which

--- a/src/log4net.Tests/Appender/TelnetAppenderTest.cs
+++ b/src/log4net.Tests/Appender/TelnetAppenderTest.cs
@@ -18,6 +18,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
@@ -30,6 +31,7 @@ using log4net.Core;
 using log4net.Layout;
 using log4net.Repository;
 using log4net.Tests.Appender.Internal;
+using log4net.Util;
 using NUnit.Framework;
 
 namespace log4net.Tests.Appender;
@@ -254,6 +256,143 @@ public sealed class TelnetAppenderTest
   public void EveryInterfaceCanBeAskedFor(string address)
     => Assert.That(new TelnetAppender { ListenAddress = IPAddress.Parse(address) }.ListenAddress,
       Is.EqualTo(IPAddress.Parse(address)));
+
+  /// <summary>
+  /// Clients are written to from a background thread, so the queue has to be bounded and the wait
+  /// for room short: it is the only delay a connected client can impose on the application.
+  /// </summary>
+  [Test]
+  public void SendQueueDefaults()
+  {
+    TelnetAppender appender = new();
+
+    Assert.That(appender.SendQueueSize, Is.EqualTo(500));
+    Assert.That(appender.EnqueueTimeoutMillis, Is.EqualTo(50));
+  }
+
+  /// <summary>
+  /// A queue of no size cannot hold anything, and a negative wait has no meaning.
+  /// </summary>
+  [Test]
+  public void SendQueueSettingsRejectMeaninglessValues()
+  {
+    TelnetAppender appender = new();
+
+    Assert.That(() => appender.SendQueueSize = 0, Throws.TypeOf<ArgumentOutOfRangeException>());
+    Assert.That(() => appender.EnqueueTimeoutMillis = -1, Throws.TypeOf<ArgumentOutOfRangeException>());
+
+    appender.EnqueueTimeoutMillis = 0;
+    Assert.That(appender.EnqueueTimeoutMillis, Is.EqualTo(0));
+  }
+
+  /// <summary>
+  /// A client that connects and then stops reading fills its receive window, and writing to it
+  /// used to block the logging thread for the whole send timeout, once per client. Logging must
+  /// now return promptly however badly the client behaves.
+  /// </summary>
+  [Test]
+  [NonParallelizable]
+  public void SlowReadersDoNotDelayLogging()
+  {
+    const int deadReaderCount = 4;
+    const int sendTimeoutMillis = 2_000;
+    // A loopback write blocks once roughly 1 MB is outstanding against the client's 1 KB receive
+    // buffer, measured, so send comfortably past that.
+    const int eventCount = 400;
+
+    int port = FindFreeTcpPort();
+    TelnetAppender appender = new()
+    {
+      Port = port,
+      ListenAddress = IPAddress.Loopback,
+      Layout = new PatternLayout("%message%newline"),
+      SendTimeoutMillis = sendTimeoutMillis
+    };
+    appender.ActivateOptions();
+
+    List<SimpleTelnetClient> deadReaders = [];
+    try
+    {
+      for (int i = 0; i < deadReaderCount; i++)
+      {
+        SimpleTelnetClient deadReader = new(_ => { }, port);
+        deadReaders.Add(deadReader);
+        deadReader.ConnectAndStopReading();
+      }
+
+      string message = new('x', 4_096);
+      Stopwatch stopwatch = Stopwatch.StartNew();
+      LogLog.ExecuteWithoutEmittingInternalMessages(() =>
+      {
+        for (int i = 0; i < eventCount; i++)
+        {
+          appender.DoAppend(CreateEvent(message));
+        }
+      });
+      stopwatch.Stop();
+
+      // Writing synchronously costs SendTimeoutMillis per stalled client before it is evicted,
+      // serially and under the appender lock: 8s here, and 100s with the 20-client cap and the
+      // default timeout. Queueing costs the enqueue wait at worst.
+      Assert.That(stopwatch.Elapsed,
+        Is.LessThan(TimeSpan.FromMilliseconds(deadReaderCount * sendTimeoutMillis / 2)),
+        "logging blocked behind clients that stopped reading");
+    }
+    finally
+    {
+      // Let the pump finish before Close waits for a drain.
+      foreach (SimpleTelnetClient deadReader in deadReaders)
+      {
+        deadReader.Dispose();
+      }
+      LogLog.ExecuteWithoutEmittingInternalMessages(appender.Close);
+    }
+  }
+
+  /// <summary>
+  /// A queue that cannot keep up drops, rather than growing or making the logging thread wait.
+  /// The loss costs the telnet stream only, so it is counted and reported once instead of per
+  /// event, which would be a denial of service of its own.
+  /// </summary>
+  [Test]
+  [NonParallelizable]
+  public void AFullQueueDropsAndReportsOnce()
+  {
+    int port = FindFreeTcpPort();
+    RecordingErrorHandler errorHandler = new();
+    TelnetAppender appender = new()
+    {
+      Port = port,
+      ListenAddress = IPAddress.Loopback,
+      Layout = new PatternLayout("%message%newline"),
+      // A queue this small fills as soon as the client stops reading, and nothing waits for room.
+      SendQueueSize = 4,
+      EnqueueTimeoutMillis = 0,
+      ErrorHandler = errorHandler
+    };
+    appender.ActivateOptions();
+
+    using SimpleTelnetClient deadReader = new(_ => { }, port);
+    try
+    {
+      deadReader.ConnectAndStopReading();
+
+      for (int i = 0; i < 200; i++)
+      {
+        appender.DoAppend(CreateEvent(new string('x', 4_096)));
+      }
+
+      Assert.That(errorHandler.Messages.FindAll(m => m.IndexOf("was dropped", StringComparison.Ordinal) >= 0),
+        Has.Count.EqualTo(1), "the drop must be reported exactly once, however many events are lost");
+    }
+    finally
+    {
+      appender.Close();
+    }
+  }
+
+  private static LoggingEvent CreateEvent(string message)
+    => new(new LoggingEventData { Level = Level.Info, Message = message, LoggerName = "TelnetTest" });
 
   /// <summary>
   /// Binding to the loopback address has to keep the port unreachable from other machines, which

--- a/src/log4net/Appender/TelnetAppender.cs
+++ b/src/log4net/Appender/TelnetAppender.cs
@@ -37,10 +37,11 @@ namespace log4net.Appender;
 /// <para>
 /// The TelnetAppender accepts socket connections and streams logging messages back to the client.
 /// The output is provided in a telnet-friendly way so that a log can be monitored over a TCP/IP socket.
-/// This allows simple remote monitoring of application logging.
 /// </para>
 /// <para>
-/// The default <see cref="Port"/> is 23 (the telnet port).
+/// The default <see cref="Port"/> is 23 (the telnet port) and the default
+/// <see cref="ListenAddress"/> is <see cref="IPAddress.Loopback"/>, so monitoring from another
+/// machine has to be turned on deliberately.
 /// </para>
 /// <para>
 /// This appender is a diagnostic tool for trusted networks. As with any other appender
@@ -57,20 +58,20 @@ public class TelnetAppender : AppenderSkeleton
   private SocketHandler? _handler;
   private int _listeningPort = 23;
   private int _sendTimeoutMillis = 5_000;
-  private IPAddress _listenAddress = IPAddress.Any;
+  private IPAddress _listenAddress = IPAddress.Loopback;
 
   /// <summary>
   /// Gets or sets the address to listen on.
   /// </summary>
   /// <value>
-  /// The local address to accept connections on. The default is <see cref="IPAddress.Any"/>, every
-  /// interface of the machine.
+  /// The local address to accept connections on. The default is <see cref="IPAddress.Loopback"/>,
+  /// the machine the application runs on.
   /// </value>
   /// <remarks>
   /// <para>
-  /// Set this to <see cref="IPAddress.Loopback"/> to accept connections only from the machine the
-  /// application runs on, which is what the diagnostic use this appender is meant for usually
-  /// needs.
+  /// The stream is unauthenticated and unencrypted, so reaching it from another machine is opt-in:
+  /// set this to <see cref="IPAddress.Any"/> or <see cref="IPAddress.IPv6Any"/> for that, and keep
+  /// untrusted parties away from the port.
   /// </para>
   /// </remarks>
   /// <exception cref="ArgumentNullException">The value specified is <see langword="null"/>.</exception>
@@ -183,7 +184,7 @@ public class TelnetAppender : AppenderSkeleton
     try
     {
       LogLog.Debug(_declaringType, $"Creating SocketHandler to listen on [{_listenAddress}]:[{_listeningPort}]");
-      _handler = new SocketHandler(_listenAddress, _listeningPort, _sendTimeoutMillis);
+      _handler = new(_listenAddress, _listeningPort, _sendTimeoutMillis);
     }
     catch (Exception ex)
     {
@@ -325,11 +326,12 @@ public class TelnetAppender : AppenderSkeleton
     /// block before that client is disconnected, or 0 to block indefinitely</param>
     /// <remarks>
     /// <para>
-    /// Creates a socket handler on the specified local server port.
+    /// Creates a socket handler on the specified local server port, listening on
+    /// <see cref="IPAddress.Loopback"/>.
     /// </para>
     /// </remarks>
     public SocketHandler(int port, int sendTimeoutMillis)
-      : this(IPAddress.Any, port, sendTimeoutMillis)
+      : this(IPAddress.Loopback, port, sendTimeoutMillis)
     { }
 
     /// <summary>

--- a/src/log4net/Appender/TelnetAppender.cs
+++ b/src/log4net/Appender/TelnetAppender.cs
@@ -24,6 +24,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using log4net.Appender.Internal;
 using log4net.Core;
 using log4net.Util;
@@ -55,10 +56,66 @@ namespace log4net.Appender;
 /// <author>Nicko Cadell</author>
 public class TelnetAppender : AppenderSkeleton
 {
+  private const int CloseTimeoutMillis = 5_000;
+
   private SocketHandler? _handler;
+  private BackgroundSender<string>? _sender;
   private int _listeningPort = 23;
   private int _sendTimeoutMillis = 5_000;
+  private int _sendQueueSize = 500;
+  private int _enqueueTimeoutMillis = 50;
   private IPAddress _listenAddress = IPAddress.Loopback;
+
+  /// <summary>
+  /// Gets or sets how many rendered events may wait to be written to the clients.
+  /// </summary>
+  /// <value>A positive number of events. The default is 500.</value>
+  /// <remarks>
+  /// <para>
+  /// Clients are written to from a background thread, so that a client which stops reading cannot
+  /// hold up the threads that log. Events queue up while that thread works, and are dropped once
+  /// the queue is full, which costs the telnet stream but never the log.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="ArgumentOutOfRangeException">The value specified is not positive.</exception>
+  public int SendQueueSize
+  {
+    get => _sendQueueSize;
+    set
+    {
+      if (value <= 0)
+      {
+        throw SystemInfo.CreateArgumentOutOfRangeException(nameof(value), value,
+          "The value specified for SendQueueSize is not positive.");
+      }
+      _sendQueueSize = value;
+    }
+  }
+
+  /// <summary>
+  /// Gets or sets how long, in milliseconds, a logging call may wait for room in the send queue.
+  /// </summary>
+  /// <value>A number of milliseconds, or 0 to drop immediately. The default is 50.</value>
+  /// <remarks>
+  /// <para>
+  /// This is the only delay a connected client can impose on the application. While the queue
+  /// stays full it caps logging at 20 events per second; 0 drops immediately instead of waiting.
+  /// </para>
+  /// </remarks>
+  /// <exception cref="ArgumentOutOfRangeException">The value specified is negative.</exception>
+  public int EnqueueTimeoutMillis
+  {
+    get => _enqueueTimeoutMillis;
+    set
+    {
+      if (value < 0)
+      {
+        throw SystemInfo.CreateArgumentOutOfRangeException(nameof(value), value,
+          "The value specified for EnqueueTimeoutMillis is negative.");
+      }
+      _enqueueTimeoutMillis = value;
+    }
+  }
 
   /// <summary>
   /// Gets or sets the address to listen on.
@@ -166,9 +223,20 @@ public class TelnetAppender : AppenderSkeleton
   {
     base.OnClose();
 
+    // Drain on a deadline, so a client that stopped reading cannot hold up shutdown.
+    if (_sender is BackgroundSender<string> sender)
+    {
+      _sender = null;
+      sender.Close(CloseTimeoutMillis);
+      sender.Dispose();
+    }
+
     _handler?.Dispose();
     _handler = null;
   }
+
+  /// <inheritdoc/>
+  public override bool Flush(int millisecondsTimeout) => _sender?.Flush(millisecondsTimeout) ?? true;
 
   /// <summary>
   /// This appender requires a <see cref="Layout"/> to be set.
@@ -185,11 +253,32 @@ public class TelnetAppender : AppenderSkeleton
     {
       LogLog.Debug(_declaringType, $"Creating SocketHandler to listen on [{_listenAddress}]:[{_listeningPort}]");
       _handler = new(_listenAddress, _listeningPort, _sendTimeoutMillis);
+      _sender = new(nameof(TelnetAppender), SendQueueSize, SendToClients, Report);
     }
     catch (Exception ex)
     {
       LogLog.Error(_declaringType, "Failed to create SocketHandler", ex);
       throw;
+    }
+  }
+
+  /// <summary>
+  /// Writes one rendered event to every client, on the background thread.
+  /// </summary>
+  private void SendToClients(string message, CancellationToken cancellationToken) => _handler?.Send(message);
+
+  /// <summary>
+  /// Reports a send failure through the appender's error handler.
+  /// </summary>
+  private void Report(string message, Exception? exception)
+  {
+    if (exception is null)
+    {
+      ErrorHandler.Error(message);
+    }
+    else
+    {
+      ErrorHandler.Error(message, exception);
     }
   }
 
@@ -201,7 +290,8 @@ public class TelnetAppender : AppenderSkeleton
   {
     if (_handler is not null && _handler.HasConnections)
     {
-      _handler.Send(RenderLoggingEvent(loggingEvent));
+      // Queued, not written: a client that stops reading must not hold up the logging thread.
+      _sender?.TryEnqueue(RenderLoggingEvent(loggingEvent), EnqueueTimeoutMillis);
     }
   }
 

--- a/src/site/antora/modules/ROOT/pages/manual/configuration/appenders/telnetappender.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/configuration/appenders/telnetappender.adoc
@@ -51,10 +51,12 @@ The default is `23`, the telnet port.
 
 `listenAddress`::
 The local address to accept connections on.
-The default is `0.0.0.0`, every interface of the machine.
+The default is `127.0.0.1`, the machine the application runs on, which is what diagnostic use
+usually needs.
 +
-Set it to `127.0.0.1` to accept connections only from the machine the application runs on, which is
-what diagnostic use usually needs.
+The stream is unauthenticated and unencrypted, so watching it from another machine is opt-in: set
+this to `0.0.0.0` for every IPv4 interface, or `::` for every IPv6 one, and keep untrusted parties
+away from the port.
 An IPv6 address may be given instead, and the listening socket follows its family.
 
 `sendTimeoutMillis`::
@@ -82,17 +84,17 @@ The appender therefore performs no authentication of its own.
 
 [WARNING]
 ====
-The connection is *unauthenticated* and *unencrypted*, and by default the appender listens on *all
-network interfaces*.
+The connection is *unauthenticated* and *unencrypted*.
 There is no option to require a credential or to enable TLS.
 
 Any client that can reach the port receives the full rendered log stream, including whatever the
 layout renders: user names, session identifiers, request parameters, stack traces.
-Keeping untrusted parties away from the port is the operator's responsibility, exactly as it is
-for a log file:
+The appender listens on `127.0.0.1` only, so that stays on the local machine until you widen
+`listenAddress`, and keeping untrusted parties away from the port is then the operator's
+responsibility, exactly as it is for a log file:
 
-* Set `listenAddress` to `127.0.0.1` unless clients on other machines really have to connect.
-* Only enable this appender on a trusted network.
+* Widen `listenAddress` only if clients on other machines really have to connect.
+* Only do so on a trusted network.
 * Restrict access to the port with a host firewall or network policy.
 * Prefer it for local or short-lived diagnostics rather than as a permanent logging destination.
 ====

--- a/src/site/antora/modules/ROOT/pages/manual/configuration/appenders/telnetappender.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/configuration/appenders/telnetappender.adoc
@@ -64,11 +64,24 @@ How long, in milliseconds, a write to a client may block before that client is t
 and disconnected.
 The default is `5000`.
 +
-Clients are written to synchronously while the appender lock is held, so a client that connects
-and then stops reading lets TCP flow control fill its receive window.
-A finite timeout bounds how long that client can hold up the threads that log through this
-appender.
-Setting the value to `0` restores blocking indefinitely and is not recommended.
+Clients are written to from a background thread, so this no longer delays the application: it is
+how long a client that stopped reading holds up the stream before it is dropped.
+`0` blocks indefinitely and is not recommended.
+
+`sendQueueSize`::
+How many rendered events may wait to be written to the clients.
+The default is `500`.
++
+A full queue drops the event from the telnet stream, counted and reported once.
+Only the telnet view is lost; every other appender still receives the event.
+
+`enqueueTimeoutMillis`::
+How long, in milliseconds, a logging call may wait for room in the send queue.
+The default is `50`.
++
+This is the only delay a client can impose on the application.
+While the queue stays full it caps logging at 20 events per second; `0` drops immediately instead
+of waiting.
 
 [#telnetappender-trust]
 == Intended use and trust model


### PR DESCRIPTION
Two findings on `TelnetAppender`, both about what a connected client can do to
the host application rather than to the log.

- **f012** The appender streams the log to any client that connects,
  unauthenticated, and defaulted to every interface on port 23. It now defaults
  to `127.0.0.1`; remote access is opt-in via `listenAddress`. Every documented
  example already used loopback.
- **f014** Clients were written to serially under the appender lock, so one that
  stopped reading held up every thread that logs for `sendTimeoutMillis`. Writes
  go through a background thread now, bounded by `sendQueueSize` (500), with a
  logging call waiting at most `enqueueTimeoutMillis` (50) for room.
  
Both change behaviour and need release notes: 
 
- Relying on the implicit all-interfaces bind loses remote access until
  `listenAddress` is set. 
- Telnet delivery is asynchronous and drops under load, never the log. While the                                      
  queue stays full, `enqueueTimeoutMillis` caps logging at 20 events/s; set it to 0                                     
  to drop immediately instead of waiting.
  
A third commit merges three copies of `RecordingErrorHandler` in the tests into
one helper, which is what the f014 test needed.
